### PR TITLE
楽天APIの設定、検索ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'rakuten_web_service'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rake (13.0.3)
+    rakuten_web_service (1.13.0)
+      json (~> 2.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -232,6 +234,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3)
   rails_best_practices
+  rakuten_web_service
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,0 +1,7 @@
+class BooksController < ApplicationController
+  def search
+    if params[:keyword]
+      @books = RakutenWebService::Books::Book.search(title: params[:keyword])
+    end
+  end
+end

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -1,3 +1,5 @@
+<%= link_to 'トップへ戻る', root_path %>
+
 <%= form_with url: books_path, method: :get, local: true do |f| %>
   <%= f.text_field :keyword %>
   <%= f.submit '本の題名を検索' %>

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -1,0 +1,10 @@
+<%= form_with url: books_path, method: :get, local: true do |f| %>
+  <%= f.text_field :keyword %>
+  <%= f.submit '本の題名を検索' %>
+<% end %>
+<% if @books.present? %>
+  <% @books.each do |book| %>
+    <p><%= book.title %></p>
+    <%= link_to (image_tag(book.medium_image_url)), book.item_url %>
+  <% end %>
+<% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,3 @@
 <h1>Home#index</h1>
 <p>Find me in app/views/home/index.html.erb</p>
+<%= link_to "本の検索", books_path %>

--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -1,0 +1,4 @@
+RakutenWebService.configure do |c|
+  # (必須) アプリケーションID
+  c.application_id = '1041555190742463154'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   root to: 'home#index'
+
+  get 'books', to: 'books#search'
 end


### PR DESCRIPTION
## 9
close #9

## 実装内容
- 楽天Webサービスの gem を追加し bundle install
- `config/initializers/rakuten.rb` にアプリケーションID を設定
- ルーティングを追加
- books コントローラに楽天API検索メソッドを追加
- search.html.erb` に検索ページを作成、トップページからのリンクを追加
- トップページへのリンクを追加

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
