### PR TITLE
タスク新規登録機能を作成

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -18,9 +18,9 @@ class BooksController < ApplicationController
   end
 
   def create
-    @book = Book.create(book_params)
+    book = Book.create(book_params)
 
-    if @book.save
+    if book.save
       flash[:success] = "本を登録しました"
       redirect_to new_task_path(book_id: @book.id)
     else

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,6 @@
 class TasksController < ApplicationController
+  before_action :authenticate_user!
+
   def index
   end
 
@@ -6,11 +8,20 @@ class TasksController < ApplicationController
   end
 
   def new
-    book_id = params[:book_id]
-    @book = Book.find_by(id: book_id)
+    @book = Book.find_by(id: params[:book_id])
+    @task = Task.new
   end
 
   def create
+    @task = current_user.tasks.build(task_params)
+
+    if @task.save
+      flash[:success] = "目標を登録しました"
+      redirect_to root_path
+    else
+      flash[:danger] = "目標の登録に失敗しました"
+      render :new
+    end
   end
 
   def edit
@@ -20,5 +31,11 @@ class TasksController < ApplicationController
   end
 
   def destroy
+  end
+
+  private
+
+  def task_params
+    params.require(:task).permit(:started_on, :finished_on, :user_id).merge(book_id: params[:book_id])
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,5 +1,7 @@
 class Book < ApplicationRecord
 
+  has_many :tasks
+
   validates :title, presence: true
   validates :image_link, format: /\A#{URI::regexp(%w(http https))}\z/
   validates :page_count, presence: true, numericality: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+
+  has_many :tasks, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,5 +1,16 @@
 <h1>Tasks#new</h1>
 
 <p><%= @book.title %></p>
-<p>開始日：<%= date_field "tasks", :started_on %></p>
-<p>終了日：<%= date_field "tasks", :finished_on %></p>
+
+<%= form_with model: @task, local: true do |f| %>
+  <%= hidden_field_tag :book_id, @book.id %>
+  <div>
+    <%= f.label :started_on, "開始日" %>
+    <%= f.date_field :started_on %>
+  </div>
+  <div>
+    <%= f.label :finished_on, "終了日" %>
+    <%= f.date_field :finished_on %>
+  </div>
+  <%= f.submit "登録" %>
+<% end %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,5 @@
 <h1>Tasks#new</h1>
-<p>Find me in app/views/tasks/new.html.erb</p>
 
-<%= @book.title %>
+<p><%= @book.title %></p>
+<p>開始日：<%= date_field "tasks", :started_on %></p>
+<p>終了日：<%= date_field "tasks", :finished_on %></p>

--- a/db/migrate/20210513015222_rename_start_date_column_to_tasks.rb
+++ b/db/migrate/20210513015222_rename_start_date_column_to_tasks.rb
@@ -1,0 +1,5 @@
+class RenameStartDateColumnToTasks < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :tasks, :start_date, :started_on
+  end
+end

--- a/db/migrate/20210513015918_rename_goal_date_column_to_tasks.rb
+++ b/db/migrate/20210513015918_rename_goal_date_column_to_tasks.rb
@@ -1,0 +1,5 @@
+class RenameGoalDateColumnToTasks < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :tasks, :goal_date, :finished_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_12_021259) do
+ActiveRecord::Schema.define(version: 2021_05_13_015918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 2021_05_12_021259) do
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.date "start_date", null: false
-    t.date "goal_date", null: false
+    t.date "started_on", null: false
+    t.date "finished_on", null: false
     t.bigint "book_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## 29
close #29

## 実装内容
- tasksテーブルのカラム名を命名規則に従い変更
- タスク新規登録ページに日付入力フォームを設置
- モデルの関連付けを設定
- タスク新規登録ページを作成

## チェックリスト

 - [ ] GitHub で Files changed を確認
 - [ ] 影響し得る範囲のローカル環境での動作確認
