### PR TITLE
フラッシュメッセージの設定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,3 +36,13 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+/* フラッシュ*/
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -21,11 +21,9 @@ class BooksController < ApplicationController
     book = Book.create(book_params)
 
     if book.save
-      flash[:success] = "本を登録しました"
-      redirect_to new_task_path(book_id: @book.id)
+      redirect_to new_task_path(book_id: @book.id), notice: "本を登録しました"
     else
-      flash[:danger] = "本の登録に失敗しました"
-      render :new
+      render :new, alert: "本の登録に失敗しました"
     end
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,11 +16,9 @@ class TasksController < ApplicationController
     @task = current_user.tasks.build(task_params)
 
     if @task.save
-      flash[:success] = "目標を登録しました"
-      redirect_to root_path
+      redirect_to root_path, notice: "目標を登録しました"
     else
-      flash[:danger] = "目標の登録に失敗しました"
-      render :new
+      render :new, alert: "目標の登録に失敗しました"
     end
   end
 

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
       <%= render 'layouts/header' %>
     </header>
     <main>
+      <%= render 'layouts/flash' %>
       <%# max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
         <%= yield %>


### PR DESCRIPTION
## 35
close #35

## 実装内容
- コントローラでフラッシュメッセージを設定
- フラッシュメッセージを表示できるように設定
- フラッシュメッセージのスタイルを設定

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
