### PR TITLE
目標進捗のCRUD処理を実装

### DIFF
--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -6,9 +6,19 @@ class ReadsController < ApplicationController
   end
 
   def new
+    @task = Task.find(params[:task_id])
+    @read = Read.new
   end
 
   def create
+    task = Task.find_by(id: params[:task_id])
+    read = task.reads.build(read_params)
+
+    if read.save
+      redirect_to task_path(task.id)
+    else
+      render "tasks/show"
+    end
   end
 
   def edit
@@ -18,5 +28,11 @@ class ReadsController < ApplicationController
   end
 
   def destroy
+  end
+
+  private
+
+  def read_params
+    params.require(:read).permit(:read_on, :read_page)
   end
 end

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -9,7 +9,7 @@ class ReadsController < ApplicationController
   def create
     read = @task.reads.build(read_params)
     if read.save
-      redirect_to task_path(@task.id)
+      redirect_to task_path(@task.id), notice: "登録しました"
     else
       render "tasks/show"
     end
@@ -20,12 +20,12 @@ class ReadsController < ApplicationController
 
   def update
     @read.update!(read_params)
-    redirect_to task_path(@task.id)
+    redirect_to task_path(@task.id), notice: "更新しました"
   end
 
   def destroy
     @read.destroy!
-    redirect_to task_path(@task.id)
+    redirect_to task_path(@task.id), alert: "削除しました"
   end
 
   private

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -1,43 +1,42 @@
 class ReadsController < ApplicationController
-  def show
-  end
+  before_action :set_task
+  before_action :set_read, only: %i[edit update destroy]
 
   def new
-    @task = Task.find(params[:task_id])
     @read = Read.new
   end
 
   def create
-    task = Task.find(params[:task_id])
-    read = task.reads.build(read_params)
-
+    read = @task.reads.build(read_params)
     if read.save
-      redirect_to task_path(task.id)
+      redirect_to task_path(@task.id)
     else
       render "tasks/show"
     end
   end
 
   def edit
-    @task = Task.find(params[:task_id])
-    @read = @task.reads.find(params[:id])
   end
 
   def update
-    task = Task.find(params[:task_id])
-    read = task.reads.find(params[:id])
-    read.update!(read_params)
-    redirect_to task_path(task.id)
+    @read.update!(read_params)
+    redirect_to task_path(@task.id)
   end
 
   def destroy
-    task = Task.find(params[:task_id])
-    read = task.reads.find(params[:id])
-    read.destroy!
-    redirect_to task_path(task.id)
+    @read.destroy!
+    redirect_to task_path(@task.id)
   end
 
   private
+
+  def set_task
+    @task = Task.find(params[:task_id])
+  end
+
+  def set_read
+    @read = @task.reads.find(params[:id])
+  end
 
   def read_params
     params.require(:read).permit(:read_on, :read_page)

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -19,9 +19,15 @@ class ReadsController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:task_id])
+    @read = @task.reads.find(params[:id])
   end
 
   def update
+    task = Task.find(params[:task_id])
+    read = task.reads.find(params[:id])
+    read.update!(read_params)
+    redirect_to task_path(task.id)
   end
 
   def destroy

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -2,6 +2,9 @@ class ReadsController < ApplicationController
   def index
   end
 
+  def show
+  end
+
   def new
   end
 

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -8,7 +8,7 @@ class ReadsController < ApplicationController
   end
 
   def create
-    task = Task.find_by(id: params[:task_id])
+    task = Task.find(params[:task_id])
     read = task.reads.build(read_params)
 
     if read.save

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -1,0 +1,19 @@
+class ReadsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -1,7 +1,4 @@
 class ReadsController < ApplicationController
-  def index
-  end
-
   def show
   end
 

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -25,6 +25,10 @@ class ReadsController < ApplicationController
   end
 
   def destroy
+    task = Task.find(params[:task_id])
+    read = task.reads.find(params[:id])
+    read.destroy!
+    redirect_to task_path(task.id)
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,7 @@ class TasksController < ApplicationController
 
   def show
     @task = Task.find(params[:id])
+    @reads = @task.reads.all.order(id: :desc)
   end
 
   def new

--- a/app/views/reads/_form.html.erb
+++ b/app/views/reads/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: [@task, @read], local: true do |f| %>
+  <div>
+    <%= f.label :read_on, "読んだ日" %>
+    <%= f.date_field :read_on, id: "read_on" %>
+  </div>
+  <div>
+    <%= f.label :read_page, "読み終えたページ番号" %>
+    <%= f.text_field :read_page, id: "read_page" %>
+  </div>
+  <%= f.submit button_value %>
+<% end %>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -1,4 +1,5 @@
 <h1>進捗一覧</h1>
+<%= link_to "進捗登録", new_task_read_path(task) %>
 <table>
   <thead>
     <tr>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -1,1 +1,21 @@
-<h3>Reads#index</h3>
+<h1>進捗一覧</h1>
+<table>
+  <thead>
+    <tr>
+      <th scope="col">No.</th>
+      <th scope="col">読んだ日</th>
+      <th scope="col">読んだページ数</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><%= read_counter + 1 %></th>
+      <td><%= read.read_on %></td>
+      <td><%= read.read_page %></td>
+      <td>
+        <%= link_to "編集", edit_task_read_path(task, read) %>
+        <%= link_to "削除", task_read_path(task, read), method: :delete, data: { confirm: "削除しますか?" } %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -8,14 +8,6 @@
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <th scope="row"><%= read_counter + 1 %></th>
-      <td><%= read.read_on %></td>
-      <td><%= read.read_page %></td>
-      <td>
-        <%= link_to "編集", edit_task_read_path(task, read) %>
-        <%= link_to "削除", task_read_path(task, read), method: :delete, data: { confirm: "削除しますか?" } %>
-      </td>
-    </tr>
+    <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
   </tbody>
 </table>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -1,0 +1,1 @@
+<h3>Reads#index</h3>

--- a/app/views/reads/_read_data.html.erb
+++ b/app/views/reads/_read_data.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <th scope="row"><%= read_counter + 1 %></th>
+  <td><%= read.read_on %></td>
+  <td><%= read.read_page %></td>
+  <td>
+    <%= link_to "編集", edit_task_read_path(task, read) %>
+    <%= link_to "削除", task_read_path(task, read), method: :delete, data: { confirm: "削除しますか?" } %>
+  </td>
+</tr>

--- a/app/views/reads/edit.html.erb
+++ b/app/views/reads/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Reads#edit</h1>
+<p>Find me in app/views/reads/edit.html.erb</p>

--- a/app/views/reads/edit.html.erb
+++ b/app/views/reads/edit.html.erb
@@ -1,2 +1,12 @@
-<h1>Reads#edit</h1>
-<p>Find me in app/views/reads/edit.html.erb</p>
+<h1>編集</h1>
+<%= form_with model: [@task, @read], local: true do |f| %>
+  <div>
+    <%= f.label :read_on, "読んだ日" %>
+    <%= f.date_field :read_on, id: "read_on" %>
+  </div>
+  <div>
+    <%= f.label :read_page, "読み終えたページ番号" %>
+    <%= f.text_field :read_page, id: "read_page" %>
+  </div>
+  <%= f.submit "更新" %>
+<% end %>

--- a/app/views/reads/edit.html.erb
+++ b/app/views/reads/edit.html.erb
@@ -1,12 +1,2 @@
 <h1>編集</h1>
-<%= form_with model: [@task, @read], local: true do |f| %>
-  <div>
-    <%= f.label :read_on, "読んだ日" %>
-    <%= f.date_field :read_on, id: "read_on" %>
-  </div>
-  <div>
-    <%= f.label :read_page, "読み終えたページ番号" %>
-    <%= f.text_field :read_page, id: "read_page" %>
-  </div>
-  <%= f.submit "更新" %>
-<% end %>
+<%= render "form", button_value: "更新" %>

--- a/app/views/reads/index.html.erb
+++ b/app/views/reads/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Reads#index</h1>
+<p>Find me in app/views/reads/index.html.erb</p>

--- a/app/views/reads/index.html.erb
+++ b/app/views/reads/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Reads#index</h1>
-<p>Find me in app/views/reads/index.html.erb</p>

--- a/app/views/reads/new.html.erb
+++ b/app/views/reads/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Reads#new</h1>
+<p>Find me in app/views/reads/new.html.erb</p>

--- a/app/views/reads/new.html.erb
+++ b/app/views/reads/new.html.erb
@@ -1,12 +1,2 @@
 <h1>進捗の新規登録</h1>
-<%= form_with model: [@task, @read], local: true do |f| %>
-  <div>
-    <%= f.label :read_on, "読んだ日" %>
-    <%= f.date_field :read_on, id: "read_on" %>
-  </div>
-  <div>
-    <%= f.label :read_page, "読み終えたページ番号" %>
-    <%= f.text_field :read_page, id: "read_page" %>
-  </div>
-  <%= f.submit "登録" %>
-<% end %>
+<%= render "form", button_value: "登録" %>

--- a/app/views/reads/new.html.erb
+++ b/app/views/reads/new.html.erb
@@ -1,2 +1,12 @@
-<h1>Reads#new</h1>
-<p>Find me in app/views/reads/new.html.erb</p>
+<h1>進捗の新規登録</h1>
+<%= form_with model: [@task, @read], local: true do |f| %>
+  <div>
+    <%= f.label :read_on, "読んだ日" %>
+    <%= f.date_field :read_on, id: "read_on" %>
+  </div>
+  <div>
+    <%= f.label :read_page, "読み終えたページ番号" %>
+    <%= f.text_field :read_page, id: "read_page" %>
+  </div>
+  <%= f.submit "登録" %>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,8 +16,7 @@
         <td><%= task.finished_on %></td>
         <td>
           <%= link_to "詳細", task %>
-          <%= link_to "編集", edit_task_path(task) %>
-          <%= link_to "削除", task, method: :delete, data: { confirm: "削除しますか?" } %>
+          <%= link_to "進捗登録", new_task_read_path(task) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,4 +9,4 @@
 <%= link_to "編集", edit_task_path(@task) %>
 <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
 
-<%= render partial: "reads/index", locals: { task: @task }, collection: @reads, as: "read" %>
+<%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -6,3 +6,7 @@
 <p>目標日数： </p>
 <p>1日の目標ページ数： </p>
 <p>進捗率： </p>
+<%= link_to "編集", edit_task_path(@task) %>
+<%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
+
+<%= render partial: "reads/index" %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,4 +9,4 @@
 <%= link_to "編集", edit_task_path(@task) %>
 <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
 
-<%= render partial: "reads/index" %>
+<%= render partial: "reads/index", locals: { task: @task }, collection: @reads, as: "read" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
   resources :books, only: [:new, :create]
   get '/books', to: 'books#search'
 
-  resources :tasks
+  resources :tasks do
+    resources :reads
+  end
 end

--- a/test/controllers/reads_controller_test.rb
+++ b/test/controllers/reads_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReadsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 48
close #48

## 実装内容
- readsコントローラとビューファイルを作成
- ルーティングを作成
- 進捗一覧、新規進捗登録ページへのリンクを追加
- 新規登録機能を実装
- 一覧ページを実装
- 削除機能を実装
- 編集機能を実装
- コントローラでフラッシュメッセージを設定
- リファクタリング
  - 進捗データ部分を部分テンプレート化
  - コントローラ処理を before_action で共通化
  - 投稿ページを部分テンプレートで共通化

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
