### PR TITLE
進捗状況のプログレスバーを実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,8 @@ class TasksController < ApplicationController
   end
 
   def show
-    @reads = @task.reads.all.order(id: :desc)
+    @reads = @task.reads.all.order(read_on: :desc)
+    @progress_data = Task.progress_data(@task)
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -14,4 +14,20 @@ class Task < ApplicationRecord
       errors.add(:finished_on, ": 開始日より前の日付は使えません")
     end
   end
+
+  # 進捗のデータをハッシュに整形
+  def self.progress_data(task)
+    max_read_page = task.reads.select(:read_page).maximum(:read_page)
+    total_pages = task.book.page_count
+
+    left_days = (task.finished_on - Date.today).to_i
+    daily_goal_pages = ( total_pages - max_read_page ) / left_days
+    percentage = 100 * max_read_page / total_pages
+
+    progress_data = {
+      left_days: left_days,
+      daily_goal_pages: daily_goal_pages,
+      percentage: percentage,
+    }
+  end
 end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -3,9 +3,15 @@
 <p>ページ数： <%= @task.book.page_count %></p>
 <p>開始日： <%= @task.started_on %></p>
 <p>終了日： <%= @task.finished_on %></p>
-<p>目標日数： </p>
-<p>1日の目標ページ数： </p>
-<p>進捗率： </p>
+<p>目標日数：あと<%= @progress_data[:left_days] %>日</p>
+<p>1日の目標ページ数： <%= @progress_data[:daily_goal_pages] %></p>
+<p>進捗率：<%= @progress_data[:percentage] %>％ </p>
+<div class="progress mb-3" style="height: 26px;">
+  <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= @progress_data[:percentage] %>%; background-color:blue %>" aria-valuenow="<%= @progress_data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
+  <%= @progress_data[:percentage] %>%
+  </div>
+</div>
+
 <%= link_to "編集", edit_task_path(@task) %>
 <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
 


### PR DESCRIPTION
## 51
close #51

## 実装内容
- taskモデルに進捗のデータをハッシュに整形するメソッドを追加
  - 目標達成日までの残り日数
  - １日の目標ページ数
  - 進捗率
- tasksコントローラから進捗データのメソッドを呼び出し
- タスク詳細ページに進捗情報を表示

## チェックリスト

 - [ ] GitHub で Files changed を確認
 - [ ] 影響し得る範囲のローカル環境での動作確認
