### PR TITLE
Feature/top page after login

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -112,58 +112,55 @@ div.field_with_errors {
   height: 35px;
   background-color: #4756ca;
 
-  .menu-inner {
-    margin: 0 auto;
+  .personal-account {
+    text-align: right;
+    line-height: 35px;
 
-    .personal-account {
-      text-align: right;
+    .account-task {
+      margin-right: 5px;
+      display: inline-block;
+      position: relative;
 
-      .account-task {
-        margin-right: 5px;
-        display: inline-block;
+      .account-task-link {
+        color: #fff;
+        padding: 5px;
+        align-items: center;
+      }
+    }
+
+    .account-menu {
+      display: inline-block;
+      position: relative;
+      cursor: pointer;
+
+      .menu-item {
+        color: #fff;
+        display: block;
+        margin-bottom: 1px;
         position: relative;
 
-        .account-task-link {
+        .menu-item-link {
+          margin-right: 5px;
           color: #fff;
-          padding: 5px;
-          align-items: center;
+          display: block;
+          text-decoration: none;
         }
       }
 
-      .account-menu {
-        display: inline-block;
-        position: relative;
-        cursor: pointer;
+      .submenu {
+        background: #fff;
+        position: absolute;
+        top: 35px;
+        right: 0;
+        left: -55px;
+        text-align: center;
+        border-radius: 0 0 4px 4px;
+        border: 1px solid #798469;
+        border-top: none;
+        padding: 0 0 0 5px;
 
-        .menu-item {
-          color: #fff;
-          display: block;
-          margin-bottom: 1px;
-          position: relative;
-
-          .menu-item-link {
-            margin-right: 5px;
-            color: #fff;
-            display: block;
-            text-decoration: none;
-          }
-        }
-
-        .submenu {
-          background: #fff;
-          position: absolute;
-          top: 25px;
-          right: 0;
-          left: -55px;
-          text-align: center;
-          border-radius: 0 0 4px 4px;
-          border: 1px solid #798469;
-          border-top: none;
-          padding: 0 0 0 5px;
-
-          .submenu-item {
-            border-bottom: 1px solid #f0f0f0;
-          }
+        .submenu-item {
+          border-bottom: 1px solid #f0f0f0;
         }
       }
     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -107,39 +107,96 @@ div.field_with_errors {
 
 /* ヘッダー */
 
-.logout-header {
+.header-menu {
   width: 100%;
   height: 35px;
   background-color: #4756ca;
-  line-height: 35px;
-  padding: 0 5px 0 5px;
-}
 
-.link {
-  color: #fff;
-}
+  .menu-inner {
+    margin: 0 auto;
 
-.login-right {
-  float: right;
+    .personal-account {
+      text-align: right;
+
+      .account-task {
+        margin-right: 5px;
+        display: inline-block;
+        position: relative;
+
+        .account-task-link {
+          color: #fff;
+          padding: 5px;
+          align-items: center;
+        }
+      }
+
+      .account-menu {
+        display: inline-block;
+        position: relative;
+        cursor: pointer;
+
+        .menu-item {
+          color: #fff;
+          display: block;
+          margin-bottom: 1px;
+          position: relative;
+
+          .menu-item-link {
+            margin-right: 5px;
+            color: #fff;
+            display: block;
+            text-decoration: none;
+          }
+        }
+
+        .submenu {
+          background: #fff;
+          position: absolute;
+          top: 25px;
+          right: 0;
+          left: -55px;
+          text-align: center;
+          border-radius: 0 0 4px 4px;
+          border: 1px solid #798469;
+          border-top: none;
+          padding: 0 0 0 5px;
+
+          .submenu-item {
+            border-bottom: 1px solid #f0f0f0;
+          }
+        }
+      }
+    }
+  }
 }
 
 .title-header {
   background-color: #fff;
   border-bottom: 1px solid #bdbdbd;
   margin: 0 auto;
+
+  .title {
+    display: inline-block;
+    margin: 10px 0 0 10px;
+    position: relative;
+  }
+
+  .search-form {
+    display: inline-block;
+    vertical-align: top;
+    margin: 20px 0 0 30px;
+    position: relative;
+  }
 }
 
-.title {
-  display: inline-block;
-  margin: 10px 0 0 10px;
-  position: relative;
+a.link {
+  color: #fff;
 }
 
-.search-form {
-  display: inline-block;
-  vertical-align: top;
-  margin: 20px 0 0 30px;
-  position: relative;
+a:hover.link {
+  color: #fff;
+  background-color: #163172;
+  text-decoration: none;
 }
 
 /* トップページ */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -405,5 +405,10 @@ img.book-image {
   .task-detail {
     display: inline-block;
     vertical-align: middle;
+
+    .task-detail-title {
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -148,6 +148,7 @@ div.field_with_errors {
       }
 
       .submenu {
+        display: none;
         background: #fff;
         position: absolute;
         top: 35px;
@@ -155,7 +156,7 @@ div.field_with_errors {
         left: -55px;
         text-align: center;
         border-radius: 0 0 4px 4px;
-        border: 1px solid #798469;
+        border: 1px solid #bdbdbd;
         border-top: none;
         padding: 0 0 0 5px;
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -400,11 +400,13 @@ img.book-image {
   .task-image {
     display: inline-block;
     vertical-align: middle;
+    margin: 10px 0 10px 0;
   }
 
   .task-detail {
     display: inline-block;
     vertical-align: middle;
+    margin: 10px 0 10px 0;
 
     .task-detail-title {
       font-weight: bold;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -390,3 +390,20 @@ img.book-image {
   text-align: center;
   padding: 12px;
 }
+
+/* タスク一覧ページ */
+
+.task {
+  border-bottom: 1px solid #bdbdbd;
+  margin-top: 5px;
+
+  .task-image {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .task-detail {
+    display: inline-block;
+    vertical-align: middle;
+  }
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = current_user.tasks.order(id: :asc)
+    @tasks = current_user.tasks.all.order(finished_on: :desc)
+    @progress_data = Task.progress_data(@tasks)
   end
 
   def show

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,7 @@ import 'bootstrap/dist/js/bootstrap';
 import 'jquery';
 import './daily_goal.js'; // 1日あたりのページ数計算
 import './search_form.js'; //書籍検索を空白時に無効化
+import './toggle_menu.js'; //ヘッダーのトグルメニュー
 
 Rails.start();
 Turbolinks.start();

--- a/app/javascript/packs/toggle_menu.js
+++ b/app/javascript/packs/toggle_menu.js
@@ -1,10 +1,8 @@
 document.addEventListener('turbolinks:load', function () {
-  $(function () {
-    $('.js-menu-item-link').each(function () {
-      $(this).on('click', function () {
-        $('+.submenu', this).slideToggle();
-        return false;
-      });
+  $('.js-menu-item-link').each(function () {
+    $(this).on('click', function () {
+      $('+.submenu', this).slideToggle();
+      return false;
     });
   });
 });

--- a/app/javascript/packs/toggle_menu.js
+++ b/app/javascript/packs/toggle_menu.js
@@ -1,0 +1,10 @@
+document.addEventListener('turbolinks:load', function () {
+  $(function () {
+    $('.js-menu-item-link').each(function () {
+      $(this).on('click', function () {
+        $('+.submenu', this).slideToggle();
+        return false;
+      });
+    });
+  });
+});

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -27,7 +27,7 @@ class Task < ApplicationRecord
     if max_read_page
       ( total_pages - max_read_page ) / left_days
     else
-      0
+      total_pages / left_days
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -32,9 +32,8 @@ class Task < ApplicationRecord
   end
 
   # 進捗のデータをハッシュに整形
-  def self.progress_data(user)
-    tasks = user.tasks.all.order(finished_on: :desc)
-    progress_data = {}
+  def self.progress_data(tasks)
+    progress_data = []
 
     tasks.each do |task|
       max_read_page = task.reads.select(:read_page).maximum(:read_page)
@@ -44,11 +43,8 @@ class Task < ApplicationRecord
       percentage = self.percentage(max_read_page, total_pages) || 0
       daily_goal_pages = self.daily_goal_pages(max_read_page, total_pages,left_days) || 0
 
-      progress_data.store(
-        task.id,
+      progress_data.push(
         {
-          title: task.book.title,
-          finished_on: task.finished_on,
           left_days: left_days,
           daily_goal_pages: daily_goal_pages,
           percentage: percentage,

--- a/app/views/books/_image_link.html.erb
+++ b/app/views/books/_image_link.html.erb
@@ -1,5 +1,5 @@
-<% if result[:image_link].present? %>
-  <%= image_tag result[:image_link], class: "book-image" %>
+<% if image_link.present? %>
+  <%= image_tag image_link, class: "book-image" %>
 <% else %>
   <%= image_tag 'book.png', class: "book-image" %>
 <% end %>

--- a/app/views/books/_image_link.html.erb
+++ b/app/views/books/_image_link.html.erb
@@ -1,0 +1,5 @@
+<% if result[:image_link].present? %>
+  <%= image_tag result[:image_link], class: "book-image" %>
+<% else %>
+  <%= image_tag 'book.png', class: "book-image" %>
+<% end %>

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -10,7 +10,7 @@
             <ul class="book-list-group">
               <% results.each do |result| %>
                 <li class="group-book">
-                  <%= render 'image_link', result: result %>
+                  <%= render partial: 'image_link', locals: { image_link: result[:image_link] } %>
                   <div class="book-detail">
                     <div class="detail-title">
                       <%= link_to result[:title], controller: :books, action: :new, class: "btn btn-primary", title: result[:title], author: result[:author], image_link: result[:image_link], page_count: result[:page_count] %>

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -10,11 +10,7 @@
             <ul class="book-list-group">
               <% results.each do |result| %>
                 <li class="group-book">
-                  <% if result[:image_link].present? %>
-                    <%= image_tag result[:image_link], class: "book-image" %>
-                  <% else %>
-                    <%= image_tag 'book.png', class: "book-image" %>
-                  <% end %>
+                  <%= render 'image_link', result: result %>
                   <div class="book-detail">
                     <div class="detail-title">
                       <%= link_to result[:title], controller: :books, action: :new, class: "btn btn-primary", title: result[:title], author: result[:author], image_link: result[:image_link], page_count: result[:page_count] %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,9 +23,8 @@
         <%= link_to "ログイン", new_user_session_path, class: "link" %>
       <% end %>
     </div>
-  <div>
+  </div>
 </div>
-
 <div class="title-header">
   <span class="title">
     <h2><%= link_to "読書の習慣", root_path %></h2>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,19 +1,34 @@
-<div class="logout-header">
-  <%= link_to 'トップへ戻る', root_path, class: "link" %>
-  <% if user_signed_in?%>
-    <%= link_to "タスク一覧", tasks_path %>
-    <%= link_to "アカウント編集", edit_user_registration_path %>
-    <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-  <% else %>
-    <span class="login-right">
-      <%= link_to "新規登録", new_user_registration_path, class: "link" %>
-      <%= link_to "ログイン", new_user_session_path, class: "link" %>
-    </span>
-  <% end %>
+<div class="header-menu">
+  <div class="menu-inner">
+    <div class="personal-account">
+      <% if user_signed_in? %>
+        <div class="account-task">
+          <%= link_to "タスク一覧", tasks_path, class: "link account-task-link" %>
+        </div>
+        <div class="account-menu">
+          <div class="menu-item">
+            <a class="menu-item-link js-menu-item-link" href="">メニュー</a>
+            <ul class="submenu">
+              <li class="submenu-item">
+                <%= link_to "アカウント編集", edit_user_registration_path %>
+              </li>
+              <li class="submenu-item">
+                <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
+              </li>
+            </ul>
+          </div>
+        </div>
+      <% else %>
+        <%= link_to "新規登録", new_user_registration_path, class: "link" %>
+        <%= link_to "ログイン", new_user_session_path, class: "link" %>
+      <% end %>
+    </div>
+  <div>
 </div>
+
 <div class="title-header">
   <span class="title">
-    <h2>読書の習慣</h2>
+    <h2><%= link_to "読書の習慣", root_path %></h2>
     <p>日々の読書目標を達成しよう！</p>
   </span>
   <span class="search-form">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="personal-account">
       <% if user_signed_in? %>
         <div class="account-task">
-          <%= link_to "タスク一覧", tasks_path, class: "link account-task-link" %>
+          <%= link_to "#{current_user.name}さんのタスク一覧", tasks_path, class: "link account-task-link" %>
         </div>
         <div class="account-menu">
           <div class="menu-item">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,20 +4,20 @@
       <div class="header-title">タスク一覧</div>
     </div>
     <div class="content-body">
-      <%= current_user.name.present? ? "#{current_user.name}さん" : "ユーザーNo.#{current_user.id}さん" %>
       <% @tasks.zip(@progress_data) do |task, data| %>
         <div class="task">
           <div class="task-image">
             <%= render partial: 'books/image_link', locals: { image_link: task.book.image_link } %>
           </div>
           <div class="task-detail">
-            <div><%= task.book.title %></div>
+            <div class="task-detail-title"><%= task.book.title %></div>
+            <div>今日の目標ページ数：<%= data[:daily_goal_pages] %>ページ </div>
             <div>目標日：<%= task.finished_on %></div>
             <div>
               <%= link_to "詳細", task %>
               <%= link_to "進捗登録", new_task_read_path(task) %>
             </div>
-            <div class="progress mt-3 mb-3" style="height: 26px; width: 500px">
+            <div class="progress mt-2 mb-3" style="height: 26px; width: 500px">
               <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= data[:percentage] %>%; background-color:blue" aria-valuenow="<%= data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
                 <%= data[:percentage] %>%
               </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,29 +5,22 @@
     </div>
     <div class="content-body">
       <%= current_user.name.present? ? "#{current_user.name}さん" : "ユーザーNo.#{current_user.id}さん" %>
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">No.</th>
-            <th scope="col">タイトル</th>
-            <th scope="col">目標日</th>
-            <th scope="col"></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @tasks.each.with_index(1) do |task, i| %>
-            <tr>
-              <th scope="row"><%= i %></th>
-              <td><%= task.book.title %></td>
-              <td><%= task.finished_on %></td>
-              <td>
-                <%= link_to "詳細", task %>
-                <%= link_to "進捗登録", new_task_read_path(task) %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <% @tasks.zip(@progress_data) do |task, data| %>
+        <div>
+          <%= render partial: 'books/image_link', locals: { image_link: task.book.image_link } %>
+        </div>
+        <div><%= task.book.title %></div>
+        <div><%= task.finished_on %></div>
+        <div>
+          <%= link_to "詳細", task %>
+          <%= link_to "進捗登録", new_task_read_path(task) %>
+        </div>
+        <div class="progress mb-3" style="height: 26px; width: 500px">
+          <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= data[:percentage] %>%; background-color:blue" aria-valuenow="<%= data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
+            <%= data[:percentage] %>%
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,25 +1,33 @@
-<%= current_user.name.present? ? "#{current_user.name}さん" : "ユーザーNo.#{current_user.id}さん" %>
-<h1>タスク一覧</h1>
-<table>
-  <thead>
-    <tr>
-      <th scope="col">No.</th>
-      <th scope="col">タイトル</th>
-      <th scope="col">目標日</th>
-      <th scope="col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @tasks.each.with_index(1) do |task, i| %>
-      <tr>
-        <th scope="row"><%= i %></th>
-        <td><%= task.book.title %></td>
-        <td><%= task.finished_on %></td>
-        <td>
-          <%= link_to "詳細", task %>
-          <%= link_to "進捗登録", new_task_read_path(task) %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="main-wrapper">
+  <div class="content-with-header">
+    <div class="content-header">
+      <div class="header-title">タスク一覧</div>
+    </div>
+    <div class="content-body">
+      <%= current_user.name.present? ? "#{current_user.name}さん" : "ユーザーNo.#{current_user.id}さん" %>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">No.</th>
+            <th scope="col">タイトル</th>
+            <th scope="col">目標日</th>
+            <th scope="col"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @tasks.each.with_index(1) do |task, i| %>
+            <tr>
+              <th scope="row"><%= i %></th>
+              <td><%= task.book.title %></td>
+              <td><%= task.finished_on %></td>
+              <td>
+                <%= link_to "詳細", task %>
+                <%= link_to "進捗登録", new_task_read_path(task) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,18 +6,22 @@
     <div class="content-body">
       <%= current_user.name.present? ? "#{current_user.name}さん" : "ユーザーNo.#{current_user.id}さん" %>
       <% @tasks.zip(@progress_data) do |task, data| %>
-        <div>
-          <%= render partial: 'books/image_link', locals: { image_link: task.book.image_link } %>
-        </div>
-        <div><%= task.book.title %></div>
-        <div><%= task.finished_on %></div>
-        <div>
-          <%= link_to "詳細", task %>
-          <%= link_to "進捗登録", new_task_read_path(task) %>
-        </div>
-        <div class="progress mb-3" style="height: 26px; width: 500px">
-          <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= data[:percentage] %>%; background-color:blue" aria-valuenow="<%= data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
-            <%= data[:percentage] %>%
+        <div class="task">
+          <div class="task-image">
+            <%= render partial: 'books/image_link', locals: { image_link: task.book.image_link } %>
+          </div>
+          <div class="task-detail">
+            <div><%= task.book.title %></div>
+            <div>目標日：<%= task.finished_on %></div>
+            <div>
+              <%= link_to "詳細", task %>
+              <%= link_to "進捗登録", new_task_read_path(task) %>
+            </div>
+            <div class="progress mt-3 mb-3" style="height: 26px; width: 500px">
+              <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= data[:percentage] %>%; background-color:blue" aria-valuenow="<%= data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
+                <%= data[:percentage] %>%
+              </div>
+            </div>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
## 53
close #53

## 実装内容
- ログイン後のヘッダーを編集
  - アカウントメニューを追加
  - ユーザー名を表示
- タスク一覧のレイアウトを編集
  - 枠を設定
  - 本の画像を表示
  - 画像と進捗のレイアウトを変更
- `app/modesl/task.rb` の個人の進捗データメソッドにユーザーの指定を追加
- 本の画像表示を部分テンプレート化

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
