### PR TITLE
タスク詳細ページのレイアウト作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -424,7 +424,7 @@ img.book-image {
 .btn-read-new-submit {
   width: 100%;
   width: 120px;
-  margin: 0 0 auto 16px;
+  margin: 0 auto 10px 0;
   display: block;
   background: #d6e4f0;
   border-radius: 100px;
@@ -433,5 +433,9 @@ img.book-image {
   color: #163172 !important;
   font-size: 16px;
   font-weight: bold;
-  padding: 10px;
+  padding: 5px;
+}
+
+.table-read {
+  width: 500px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,10 @@ ul li {
   list-style: none;
 }
 
+th {
+  color: #163172;
+}
+
 .base-container {
   margin: 5px auto 0;
   padding: 1rem;
@@ -413,4 +417,21 @@ img.book-image {
       margin-bottom: 5px;
     }
   }
+}
+
+/* タスク詳細ページ */
+
+.btn-read-new-submit {
+  width: 100%;
+  width: 120px;
+  margin: 0 0 auto 16px;
+  display: block;
+  background: #d6e4f0;
+  border-radius: 100px;
+  border: 1px solid #1e56a0;
+  box-sizing: border-box;
+  color: #163172 !important;
+  font-size: 16px;
+  font-weight: bold;
+  padding: 10px;
 }

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -9,7 +9,7 @@ class ReadsController < ApplicationController
   def create
     @read = @task.reads.build(read_params)
     if @read.save
-      redirect_to task_path(@task.id), notice: "登録しました"
+      redirect_to tasks_path(@task.id), notice: "登録しました"
     else
       flash.now[:alert] = "登録に失敗しました"
       render :new

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -9,7 +9,7 @@ class ReadsController < ApplicationController
   def create
     @read = @task.reads.build(read_params)
     if @read.save
-      redirect_to tasks_path(@task.id), notice: "登録しました"
+      redirect_to task_path(@task.id), notice: "登録しました"
     else
       flash.now[:alert] = "登録に失敗しました"
       render :new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
 
   def show
     @reads = @task.reads.all.order(read_on: :desc)
-    @progress_data = JSON.parse params[:data]
+    @progress_data = Task.task_progress_data(@task)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
 
   def show
     @reads = @task.reads.all.order(read_on: :desc)
-    @progress_data = Task.progress_data(@task)
+    @progress_data = JSON.parse params[:data]
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -15,6 +15,7 @@ class Task < ApplicationRecord
     end
   end
 
+  # 読書進捗のパーセンテージを計算
   def self.percentage(max_read_page, total_pages)
     if max_read_page
        100 * max_read_page / total_pages
@@ -23,6 +24,7 @@ class Task < ApplicationRecord
     end
   end
 
+  # 目標日と総ページ数から1日の目標ページ数を計算
   def self.daily_goal_pages(max_read_page, total_pages, left_days)
     if max_read_page
       ( total_pages - max_read_page ) / left_days
@@ -30,7 +32,13 @@ class Task < ApplicationRecord
       total_pages / left_days
     end
   end
+ 
+  # 今日の日付から目標日までの残り日数を計算
+  def self.left_days(task)
+    left_days = (task.finished_on - Date.today).to_i
+  end
 
+  # タスク一覧ページ
   # 進捗のデータをハッシュに整形
   def self.progress_data(tasks)
     progress_data = []
@@ -39,7 +47,7 @@ class Task < ApplicationRecord
       max_read_page = task.reads.select(:read_page).maximum(:read_page)
       total_pages = task.book.page_count
 
-      left_days = (task.finished_on - Date.today).to_i
+      left_days = self.left_days(task)
       percentage = self.percentage(max_read_page, total_pages) || 0
       daily_goal_pages = self.daily_goal_pages(max_read_page, total_pages,left_days) || 0
 

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -1,14 +1,22 @@
-<h1>進捗一覧</h1>
-<%= link_to "進捗登録", new_task_read_path(task) %>
-<table>
-  <thead>
-    <tr>
-      <th scope="col">No.</th>
-      <th scope="col">読んだ日</th>
-      <th scope="col">読んだページ数</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
-  </tbody>
-</table>
+<div class="main-wrapper">
+  <div class="content-with-header">
+    <div class="content-header">
+      <div class="header-title">進捗一覧</div>
+    </div>
+    <div class="content-body">
+      <%= link_to "進捗登録", new_task_read_path(task) %>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">No.</th>
+            <th scope="col">読んだ日</th>
+            <th scope="col">読んだページ数</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -5,12 +5,13 @@
     </div>
     <div class="content-body">
       <%= link_to "進捗登録", new_task_read_path(task), class: "btn btn-read-new-submit" %>
-      <table>
+      <table class="table table-sm table-read">
         <thead>
           <tr>
-            <th scope="col">No.</th>
+            <th scope="col"></th>
             <th scope="col">読んだ日</th>
             <th scope="col">読んだページ数</th>
+            <th scope="col"></th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -4,7 +4,7 @@
       <div class="header-title">進捗一覧</div>
     </div>
     <div class="content-body">
-      <%= link_to "進捗登録", new_task_read_path(task) %>
+      <%= link_to "進捗登録", new_task_read_path(task), class: "btn btn-read-new-submit" %>
       <table>
         <thead>
           <tr>

--- a/app/views/tasks/_percentage.html.erb
+++ b/app/views/tasks/_percentage.html.erb
@@ -1,0 +1,10 @@
+<div class="progress" style="height: 26px; width: 400px;">
+  <div class="progress-bar progress-bar-striped"
+    role="progressbar"
+    style="width:<%= percentage %>%; background-color:blue;"
+    aria-valuenow="<%= percentage %>"
+    aria-valuemin="0"
+    aria-valuemax="100">
+    <%= percentage %>%
+  </div>
+</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -14,10 +14,7 @@
             <div>今日の目標ページ数：<%= data[:daily_goal_pages] %>ページ </div>
             <div>目標日：<%= task.finished_on %></div>
             <div>
-              <%= form_with(url: task_path(task.id), method: :get, local: true) do |f| %>
-                <%= hidden_field_tag :data, data.to_json %>
-                <%= f.submit "詳細" %>
-              <% end %>
+              <%= link_to "詳細", task %>
               <%= link_to "進捗登録", new_task_read_path(task) %>
             </div>
             <%= render 'percentage', percentage: data[:percentage] %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -20,11 +20,7 @@
               <% end %>
               <%= link_to "進捗登録", new_task_read_path(task) %>
             </div>
-            <div class="progress mt-2 mb-3" style="height: 26px; width: 500px">
-              <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= data[:percentage] %>%; background-color:blue" aria-valuenow="<%= data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
-                <%= data[:percentage] %>%
-              </div>
-            </div>
+            <%= render 'percentage', percentage: data[:percentage] %>
           </div>
         </div>
       <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -14,7 +14,10 @@
             <div>今日の目標ページ数：<%= data[:daily_goal_pages] %>ページ </div>
             <div>目標日：<%= task.finished_on %></div>
             <div>
-              <%= link_to "詳細", task %>
+              <%= form_with(url: task_path(task.id), method: :get, local: true) do |f| %>
+                <%= hidden_field_tag :data, data.to_json %>
+                <%= f.submit "詳細" %>
+              <% end %>
               <%= link_to "進捗登録", new_task_read_path(task) %>
             </div>
             <div class="progress mt-2 mb-3" style="height: 26px; width: 500px">

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -23,17 +23,17 @@
         </tr>
         <tr>
           <th>目標日まで</th>
-          <td>あと<%= @progress_data["left_days"] %>日</td>
+          <td>あと<%= @progress_data[0][:left_days] %>日</td>
         </tr>
         <tr>
           <th>1日の目標ページ数</th>
-          <td><%= @progress_data["daily_goal_pages"] %></td>
+          <td><%= @progress_data[0][:daily_goal_pages] %></td>
         </tr>
         <tr>
           <th>進捗率</th>
           <td>
-            <%= @progress_data["percentage"] %>％
-            <%= render 'percentage', percentage: @progress_data["percentage"] %>
+            <%= @progress_data[0][:percentage] %>％
+            <%= render 'percentage', percentage: @progress_data[0][:percentage] %>
           </td>
         </tr>
       </table>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,18 +4,39 @@
       <div class="header-title">タスク詳細</div>
     </div>
     <div class="content-body">
-      <p>本のタイトル： <%= @task.book.title %></p>
-      <p>ページ数： <%= @task.book.page_count %></p>
-      <p>開始日： <%= @task.started_on %></p>
-      <p>終了日： <%= @task.finished_on %></p>
-      <p>目標日数：あと<%= @progress_data["left_days"] %>日</p>
-      <p>1日の目標ページ数： <%= @progress_data["daily_goal_pages"] %></p>
-      <p>進捗率：<%= @progress_data["percentage"] %>％ </p>
-      <div class="progress mb-3" style="height: 26px;">
-        <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= @progress_data["percentage"] %>%; background-color:blue %>" aria-valuenow="<%= @progress_data["percentage"] %>" aria-valuemin="0" aria-valuemax="100">
-        <%= @progress_data["percentage"] %>%
-        </div>
-      </div>
+      <table class="table table-bordered table-sm">
+        <tr>
+          <th>本のタイトル</th>
+          <td><%= @task.book.title %></td>
+        </tr>
+        <tr>
+          <th>ページ数</th>
+          <td><%= @task.book.page_count %></td>
+        </tr>
+        <tr>
+          <th>開始日</th>
+          <td><%= @task.started_on %></td>
+        </tr>
+        <tr>
+          <th>目標日</th>
+          <td><%= @task.finished_on %></td>
+        </tr>
+        <tr>
+          <th>目標日まで</th>
+          <td>あと<%= @progress_data["left_days"] %>日</td>
+        </tr>
+        <tr>
+          <th>1日の目標ページ数</th>
+          <td><%= @progress_data["daily_goal_pages"] %></td>
+        </tr>
+        <tr>
+          <th>進捗率</th>
+          <td>
+            <%= @progress_data["percentage"] %>％
+            <%= render 'percentage', percentage: @progress_data["percentage"] %>
+          </td>
+        </tr>
+      </table>
       <%= link_to "編集", edit_task_path(@task) %>
       <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
     </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -3,12 +3,12 @@
 <p>ページ数： <%= @task.book.page_count %></p>
 <p>開始日： <%= @task.started_on %></p>
 <p>終了日： <%= @task.finished_on %></p>
-<p>目標日数：あと<%= @progress_data[:left_days] %>日</p>
-<p>1日の目標ページ数： <%= @progress_data[:daily_goal_pages] %></p>
-<p>進捗率：<%= @progress_data[:percentage] %>％ </p>
+<p>目標日数：あと<%= @progress_data["left_days"] %>日</p>
+<p>1日の目標ページ数： <%= @progress_data["daily_goal_pages"] %></p>
+<p>進捗率：<%= @progress_data["percentage"] %>％ </p>
 <div class="progress mb-3" style="height: 26px;">
-  <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= @progress_data[:percentage] %>%; background-color:blue %>" aria-valuenow="<%= @progress_data[:percentage] %>" aria-valuemin="0" aria-valuemax="100">
-  <%= @progress_data[:percentage] %>%
+  <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= @progress_data["percentage"] %>%; background-color:blue %>" aria-valuenow="<%= @progress_data["percentage"] %>" aria-valuemin="0" aria-valuemax="100">
+  <%= @progress_data["percentage"] %>%
   </div>
 </div>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,18 +1,25 @@
-<h1>タスク詳細</h1>
-<p>本のタイトル： <%= @task.book.title %></p>
-<p>ページ数： <%= @task.book.page_count %></p>
-<p>開始日： <%= @task.started_on %></p>
-<p>終了日： <%= @task.finished_on %></p>
-<p>目標日数：あと<%= @progress_data["left_days"] %>日</p>
-<p>1日の目標ページ数： <%= @progress_data["daily_goal_pages"] %></p>
-<p>進捗率：<%= @progress_data["percentage"] %>％ </p>
-<div class="progress mb-3" style="height: 26px;">
-  <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= @progress_data["percentage"] %>%; background-color:blue %>" aria-valuenow="<%= @progress_data["percentage"] %>" aria-valuemin="0" aria-valuemax="100">
-  <%= @progress_data["percentage"] %>%
+<div class="main-wrapper">
+  <div class="content-with-header">
+    <div class="content-header">
+      <div class="header-title">タスク詳細</div>
+    </div>
+    <div class="content-body">
+      <p>本のタイトル： <%= @task.book.title %></p>
+      <p>ページ数： <%= @task.book.page_count %></p>
+      <p>開始日： <%= @task.started_on %></p>
+      <p>終了日： <%= @task.finished_on %></p>
+      <p>目標日数：あと<%= @progress_data["left_days"] %>日</p>
+      <p>1日の目標ページ数： <%= @progress_data["daily_goal_pages"] %></p>
+      <p>進捗率：<%= @progress_data["percentage"] %>％ </p>
+      <div class="progress mb-3" style="height: 26px;">
+        <div class="progress-bar progress-bar-striped" role="progressbar" style="width:<%= @progress_data["percentage"] %>%; background-color:blue %>" aria-valuenow="<%= @progress_data["percentage"] %>" aria-valuemin="0" aria-valuemax="100">
+        <%= @progress_data["percentage"] %>%
+        </div>
+      </div>
+      <%= link_to "編集", edit_task_path(@task) %>
+      <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
+    </div>
   </div>
 </div>
-
-<%= link_to "編集", edit_task_path(@task) %>
-<%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
 
 <%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -6,31 +6,31 @@
     <div class="content-body">
       <table class="table table-bordered table-sm">
         <tr>
-          <th>本のタイトル</th>
+          <th scope="row">本のタイトル</th>
           <td><%= @task.book.title %></td>
         </tr>
         <tr>
-          <th>ページ数</th>
+          <th scope="row">ページ数</th>
           <td><%= @task.book.page_count %></td>
         </tr>
         <tr>
-          <th>開始日</th>
+          <th scope="row">開始日</th>
           <td><%= @task.started_on %></td>
         </tr>
         <tr>
-          <th>目標日</th>
+          <th scope="row">目標日</th>
           <td><%= @task.finished_on %></td>
         </tr>
         <tr>
-          <th>目標日まで</th>
+          <th scope="row">目標日まで</th>
           <td>あと<%= @progress_data[0][:left_days] %>日</td>
         </tr>
         <tr>
-          <th>1日の目標ページ数</th>
+          <th scope="row">1日の目標ページ数</th>
           <td><%= @progress_data[0][:daily_goal_pages] %></td>
         </tr>
         <tr>
-          <th>進捗率</th>
+          <th scope="row">進捗率</th>
           <td>
             <%= @progress_data[0][:percentage] %>％
             <%= render 'percentage', percentage: @progress_data[0][:percentage] %>


### PR DESCRIPTION
## 70
close #70

## 実装内容
- タスク詳細ページにスタイルを適用
- タスク詳細欄のレイアウトを整え
- 進捗一覧のレイアウトを整え
- プログレスバーを部分テンプレート化
- タスク進捗データのメソッドを変更

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
