### PR TITLE
進捗登録ページのレイアウトを作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -439,3 +439,56 @@ img.book-image {
 .table-read {
   width: 500px;
 }
+
+/* 進捗新規登録ページ */
+
+.form-field {
+  padding: 10px 0 10px;
+  border-bottom: 1px solid #f0f0f0;
+
+  .field-caption {
+    display: inline-block;
+    position: relative;
+    width: 200px;
+    padding: 4px 15px 6px 0;
+    margin: 0;
+    text-align: left;
+   
+    label {
+      line-height: 24px;
+    }
+  }
+
+  .field-input {
+    width: 250px;
+    text-align: left;
+    display: inline-block;
+    position: relative;
+
+    input[type="date"], input[type="text"] {
+      border-radius: 5px;
+      font-size: 13px;
+      line-height: 1;
+      padding: 10px 30px 10px 10px;
+      width: 100%;
+      box-sizing: border-box;
+      border: 1px solid #ccc;
+    }
+  }
+}
+
+.btn-read-new {
+  input[type="submit"] {
+    width: 120px;
+    margin: 10px auto 13px 200px;
+    display: block;
+    background: #d6e4f0;
+    border-radius: 100px;
+    border: 1px solid #1e56a0;
+    box-sizing: border-box;
+    color: #163172 !important;
+    font-size: 16px;
+    font-weight: bold;
+    padding: 5px;
+  }
+}

--- a/app/views/reads/_form.html.erb
+++ b/app/views/reads/_form.html.erb
@@ -1,12 +1,22 @@
 <%= form_with model: [task, read], local: true do |f| %>
   <%= render 'layouts/error_messages', model: f.object %>
-  <div>
-    <%= f.label :read_on %>
-    <%= f.date_field :read_on %>
+  <div class="form-field">
+    <div class="field-caption">
+      <%= f.label :read_on %>
+    </div>
+    <div class="field-input">
+      <%= f.date_field :read_on %>
+    </div>
   </div>
-  <div>
-    <%= f.label :read_page %>
-    <%= f.text_field :read_page %>
+  <div class="form-field">
+    <div class="field-caption">
+      <%= f.label :read_page %>
+    </div>
+    <div class="field-input">
+      <%= f.text_field :read_page %>
+    </div>
   </div>
-  <%= f.submit button_value %>
+  <div class="btn-read-new">
+    <%= f.submit button_value %>
+  </div>
 <% end %>

--- a/app/views/reads/new.html.erb
+++ b/app/views/reads/new.html.erb
@@ -1,2 +1,10 @@
-<h1>進捗の新規登録</h1>
-<%= render "form", task: @task, read: @read, button_value: "登録" %>
+<div class="main-wrapper">
+  <div class="content-with-header">
+    <div class="content-header">
+      <div class="header-title">進捗の新規登録</div>
+    </div>
+    <div class="content-body">
+      <%= render "form", task: @task, read: @read, button_value: "登録" %>
+    </div>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,10 +21,10 @@ ja:
         started_on: 開始日
         finished_on: 終了日
       read:
-        read_on: 読書日
+        read_on: 読んだ日
         read_page: 読み終わったページ番号
       task/reads:
-        read_on: 読書日
+        read_on: 読んだ日
         read_page: 読み終わったページ番号
   date:
     abbr_day_names:


### PR DESCRIPTION
## 72
close #72

## 実装内容
- 進捗登録ページにスタイルを適用
- 進捗新規登録の入力フォームにクラスを追加
- CSSにレイアウトを追加
- `read_on` の日本語訳を変更

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
