### PR TITLE
タスク新規登録ページのレイアウトを作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -513,3 +513,25 @@ img.book-image {
     padding: 5px;
   }
 }
+
+/* タスク新規登録ページ */
+
+.caption-task-new {
+  width: 70px !important;
+}
+
+.table-task-new {
+  table-layout: fixed;
+  width: 500px;
+  overflow: hidden;
+
+  th {
+    width: 160px;
+  }
+}
+
+.btn-task-new {
+  input[type="submit"]{
+    margin-left: 50px;
+  }
+}

--- a/app/javascript/packs/daily_goal.js
+++ b/app/javascript/packs/daily_goal.js
@@ -4,12 +4,12 @@ document.addEventListener("turbolinks:load", function(){
     var finish = $("#finished_on").val();
     var dateStart = Date.parse(start);
     var dateFinish = Date.parse(finish);
-    var pageCount = $("#page").data("page-id")
+    var pageCount = $("#page").data("page-id");
 
     var resultDays = (dateFinish - dateStart) / 86400000;
-    var resultPages = Math.ceil( pageCount / resultDays )
+    var resultPages = Math.ceil( pageCount / resultDays );
 
     $("#days").html(resultDays);
-    $("#page").html(resultPages)
+    $("#page").html(resultPages);
   });
 });

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,23 +1,47 @@
-<h1>Tasks#new</h1>
+<div class="main-wrapper">
+  <div class="content-with-header">
+    <div class="content-header">
+      <div class="header-title">タスク新規登録</div>
+    </div>
+    <div class="content-body">
+      <table class="table table-bordered table-sm table-task-new">
+        <tr>
+          <th scope="row">タイトル</th>
+          <td><%= @book.title %></td>
+        </tr>
+        <tr>
+          <th scope="row">日数</th>
+          <td><span id="days"></span></td>
+        </tr>
+        <tr>
+          <th scope="row">1日の目標ページ数</th>
+          <td><span id="page", data-page-id="<%= @book.page_count %>"></span></td>
+        </tr>
+      </table>
 
-<p><%= @book.title %></p>
-
-<%= form_with model: @task, local: true do |f| %>
-  <%= render 'layouts/error_messages', model: f.object %>
-  <%= hidden_field_tag :book_id, @book.id %>
-  <div>
-    <%= f.label :started_on %>
-    <%= f.date_field :started_on, id: "started_on" %>
+      <%= form_with model: @task, local: true do |f| %>
+        <%= render 'layouts/error_messages', model: f.object %>
+        <%= hidden_field_tag :book_id, @book.id %>
+        <div class="form-field">
+          <div class="field-caption caption-task-new">
+            <%= f.label :started_on %>
+          </div>
+          <div class="field-input">
+            <%= f.date_field :started_on, id: "started_on" %>
+          </div>
+        </div>
+        <div class="form-field">
+          <div class="field-caption caption-task-new">
+            <%= f.label :finished_on %>
+          </div>
+          <div class="field-input">
+            <%= f.date_field :finished_on, id: "finished_on" %>
+          </div>
+        </div>
+        <div class="btn-read-new btn-task-new">
+          <%= f.submit "登録" %>
+        </div>
+      <% end %>
+    </div>
   </div>
-  <div>
-    <%= f.label :finished_on %>
-    <%= f.date_field :finished_on, id: "finished_on" %>
-  </div>
-  <%= f.submit "登録" %>
-<% end %>
-<div>
-  日数：<span id="days"></span>
-</div>
-<div>
-  1日あたりのページ数：<span id="page", data-page-id="<%= @book.page_count %>"</span>
 </div>


### PR DESCRIPTION
## 76
close #76

## 実装内容
- タスク新規登録ページのレイアウトを変更
- 1日あたりの日数やページ数を計算するjsファイルを微修正

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
