### PR TITLE
アカウント編集ページのレイアウトを作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -535,3 +535,71 @@ img.book-image {
     margin-left: 50px;
   }
 }
+
+/* アカウント編集ページ */
+
+.field-account-edit {
+  padding: 10px 0 10px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.edit-submit-btn {
+  appearance: none;
+  outline: none;
+  width: 100%;
+  display: block;
+  background: #4756ca;
+  border-radius: 100px;
+  border: 1px solid #4756ca;
+  box-sizing: border-box;
+  color: #fff !important;
+  font-size: 16px;
+  font-weight: bold;
+  text-align: center;
+  padding: 12px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.cancel-guide-wrap {
+  text-align: center;
+  padding-top: 15px;
+  margin-top: 15px;
+
+  .cancel-border-wrap {
+    border-top: 1px solid #999;
+    box-sizing: border-box;
+    height: 30px;
+  }
+
+  .cancel-guide-text {
+    font-size: 14px;
+    color: #999;
+    height: 30px;
+    line-height: 30px;
+    margin: -15px auto 0;
+    background: #fff;
+    width: 17em;
+  }
+}
+
+.cancel-btn-wrap {
+  width: 100%;
+  max-width: 420px;
+  min-width: 120px;
+  margin: 0 auto 16px;
+
+  .cancel-submit-btn {
+    width: 100%;
+    display: block;
+    background: #bdbdbd;
+    border-radius: 100px;
+    border: 1px solid #bdbdbd;
+    box-sizing: border-box;
+    color: #313f52 !important;
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
+    padding: 12px;
+  }
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,48 +1,63 @@
-<h2><%= t('.title', resource: resource.model_name.human) %></h2>
+<div class="main-wrapper">
+  <div class="content-with-header">
+    <div class="content-header">
+      <div class="header-title"><%= t('.title', resource: resource.model_name.human) %></div>
+    </div>
+    <div class="content-body">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :name, "ユーザーネーム" %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+        <div class="field-account-edit">
+          <%= f.label :name, "ユーザーネーム", class: "field-title" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "field-field" %>
+        </div>
+
+        <div class="field-account-edit">
+          <%= f.label :email, class: "field-title" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "field-field" %>
+        </div>
+
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+        <% end %>
+
+        <div class="field-account-edit">
+          <%= f.label :password, class: "field-title" %>
+          <i class="field-title">(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i>
+          <% if @minimum_password_length %>
+            <span class="field-title"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></span>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "field-field" %>
+        </div>
+
+        <div class="field-account-edit">
+          <%= f.label :password_confirmation, class: "field-title" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "field-field" %>
+        </div>
+
+        <div class="field-account-edit">
+          <%= f.label :current_password, class: "field-title" %>
+          <i class="field-title">(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i>
+          <%= f.password_field :current_password, autocomplete: "current-password", class: "field-field" %>
+        </div>
+
+        <div class="actions">
+          <%= f.submit t('.update'), class: "edit-submit-btn" %>
+        </div>
+      <% end %>
+
+      <div class="cancel-guide-wrap">
+        <div class= "cancel-border-wrap">
+          <p class="cancel-guide-text"><%= t('.cancel_my_account') %>したい方はこちら</p>
+        </div>
+      </div>
+
+      <div class="cancel-btn-wrap">
+        <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "cancel-submit-btn" %>
+      </div>
+
+      <%= link_to t('devise.shared.links.back'), :back %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit t('.update') %>
-  </div>
-<% end %>
-
-<h3><%= t('.cancel_my_account') %></h3>
-
-<p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
-
-<%= link_to t('devise.shared.links.back'), :back %>
+</div>


### PR DESCRIPTION
## 78
close #78

## 実装内容
- アカウント編集ページのレイアウトを作成

## チェックリスト

 - [ ] GitHub で Files changed を確認
 - [ ] 影響し得る範囲のローカル環境での動作確認
