### PR TITLE
タスク詳細ページ、一覧ページのリンクを変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'devise'
 gem 'rails-i18n', '~> 6.0'
 gem 'devise-i18n'
 gem "simple_calendar", "~> 2.4"
+gem "chartkick"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (4.0.5)
     childprocess (3.0.0)
     code_analyzer (0.5.2)
       sexp_processor
@@ -254,6 +255,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  chartkick
   devise
   devise-i18n
   jbuilder (~> 2.7)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -513,6 +513,28 @@ img.book-image {
   width: 694px;
 }
 
+.header-title-task-tab {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  height: 50px;
+  position: relative;
+  display: inline-block;
+  padding: 0 15px;
+  box-sizing: border-box;
+  font-weight: bold;
+  line-height: 50px;
+}
+
+a.header-title-task-tab {
+  text-decoration: none;
+  color: #212121;
+}
+
+a.selected {
+  border-bottom: 4px solid #4756ca;
+}
+
 /* タスク一覧ページ、サイドバー */
 
 .side-wrapper {
@@ -582,6 +604,47 @@ img.book-image {
     .task-detail-title {
       font-weight: bold;
       margin-bottom: 5px;
+      font-size: 15px;
+    }
+
+    .task-detail-today-page-number {
+      display: flex;
+      margin-bottom: 5px;
+      margin-left: 10px;
+      height: 30px;
+      line-height: 30px;
+
+      .number-title {
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+        border-top: 1px solid #bdbdbd;
+        border-bottom: 1px solid #bdbdbd;
+        border-left: 1px solid #bdbdbd;
+        box-sizing: border-box;
+        background-color: #bde4f4;
+        font-size: 15px;
+        padding: 0 5px 0 5px;
+      }
+
+      .number-item {
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-top: 1px solid #bdbdbd;
+        border-bottom: 1px solid #bdbdbd;
+        border-right: 1px solid #bdbdbd;
+        box-sizing: border-box;
+        color: #4756ca;
+        font-size: 13px;
+        padding: 0 5px;
+      }
+    }
+
+    .task-detail-today-page {
+      font-size: 13px;
+    }
+
+    .task-detail-finish-date {
+      font-size: 13px;
     }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -772,6 +772,10 @@ a.selected {
   width: 500px;
 }
 
+.reads-index {
+  margin-top: 20px;
+}
+
 /* 進捗新規登録ページ */
 
 .form-field {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :first_task
 
   private
 
@@ -11,5 +12,10 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resorce)
     tasks_path
+  end
+
+  def first_task
+    task = Task.joins(:reads).order(read_on: :desc).limit(1)
+    @first_task = task[0]
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -20,6 +20,7 @@ class TasksController < ApplicationController
 
     @reads = @task.reads.all.order(read_on: :desc)
     @task_progress_data = Task.task_progress_data(@task)
+    @progress_percentage = { read: @task_progress_data[0][:percentage], unread: 100 - @task_progress_data[0][:percentage] }
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,17 +1,25 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_task, only: %i[show edit update destroy]
-
-  def index
-    @tasks = current_user.tasks.all.order(finished_on: :desc)
-    @progress_data = Task.progress_data(@tasks)
+  before_action :side_bar, only: %i[index show]
+  
+  def side_bar
     @reads = current_user.reads
     @month_data = Read.month_data(current_user)
   end
 
+  def index
+    @tasks = current_user.tasks.all.order(finished_on: :desc)
+    @progress_data = Task.progress_data(@tasks)
+  end
+
   def show
+    if params
+      @task = Task.find(params[:id])
+    end
+
     @reads = @task.reads.all.order(read_on: :desc)
-    @progress_data = Task.task_progress_data(@task)
+    @task_progress_data = Task.task_progress_data(@task)
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,6 +12,7 @@ import 'jquery';
 import './daily_goal.js'; // 1日あたりのページ数計算
 import './search_form.js'; //書籍検索を空白時に無効化
 import './toggle_menu.js'; //ヘッダーのトグルメニュー
+import "chartkick/highcharts"
 
 Rails.start();
 Turbolinks.start();

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="personal-account">
       <% if user_signed_in? %>
         <div class="account-task">
-          <%= link_to "#{current_user.name}さんのタスク一覧", tasks_path, class: "link account-task-link" %>
+          <%= link_to "#{current_user.name}さんのタスク一覧", task_path(first_task.id), class: "link account-task-link" %>
         </div>
         <div class="account-menu">
           <div class="menu-item">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="personal-account">
       <% if user_signed_in? %>
         <div class="account-task">
-          <%= link_to "#{current_user.name}さんのタスク一覧", task_path(first_task.id), class: "link account-task-link" %>
+          <%= link_to "#{current_user.name}さんのマイページ", task_path(first_task.id), class: "link account-task-link" %>
         </div>
         <div class="account-menu">
           <div class="menu-item">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 
   <body>
     <header>
-      <%= render 'layouts/header' %>
+      <%= render 'layouts/header', first_task: @first_task %>
     </header>
     <main>
       <%= render 'layouts/flash' %>

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -1,23 +1,21 @@
-<div class="main-wrapper">
-  <div class="content-with-header">
-    <div class="content-header">
-      <div class="header-title">進捗一覧</div>
-    </div>
-    <div class="content-body">
-      <%= link_to "進捗登録", new_task_read_path(task), class: "btn btn-read-new-submit" %>
-      <table class="table table-sm table-read">
-        <thead>
-          <tr>
-            <th scope="col"></th>
-            <th scope="col">読んだ日</th>
-            <th scope="col">読んだページ数</th>
-            <th scope="col"></th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
-        </tbody>
-      </table>
-    </div>
+<div class="reads-index">
+  <div class="content-header">
+    <div class="header-title">進捗一覧</div>
+  </div>
+  <div class="content-body">
+    <%= link_to "進捗登録", new_task_read_path(task), class: "btn btn-read-new-submit" %>
+    <table class="table table-sm table-read">
+      <thead>
+        <tr>
+          <th scope="col"></th>
+          <th scope="col">読んだ日</th>
+          <th scope="col">読んだページ数</th>
+          <th scope="col"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,10 +2,12 @@
   <div class="side-wrapper">
     <%= render 'side' %>
   </div>
+
   <div class="main-wrapper-task">
     <div class="content-with-header">
       <div class="content-header">
-        <div class="header-title">タスク一覧</div>
+        <%= link_to 'タスク', task_path(@first_task.id), class: "header-title-task-tab" %>
+        <%= link_to 'タスク一覧', tasks_path, class: "header-title-task-tab selected" %>
       </div>
       <div class="content-body">
         <% @tasks.zip(@progress_data) do |task, data| %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -15,8 +15,12 @@
             </div>
             <div class="task-detail">
               <div class="task-detail-title"><%= task.book.title %></div>
-              <div>今日の目標ページ数：<%= data[:daily_goal_pages] %>ページ </div>
-              <div>目標日：<%= task.finished_on %></div>
+              <div class="task-detail-today-page-number">
+                <div class="number-title"><i class="fa fa-book" aria-hidden="true"></i>今日の目標</div>
+                <div class="number-item"><%= data[:today_page_number] %>頁まで</div>
+              </div>
+              <div class="task-detail-today-page">今日読むページ数：<%= data[:daily_goal_pages] %>ページ</div>
+              <div class="task-detail-finish-date">目標日：<%= task.finished_on.strftime("%-m月%-d日") %></div>
               <div>
                 <%= link_to "詳細", task %>
                 <%= link_to "進捗登録", new_task_read_path(task) %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,6 +9,7 @@
         <%= link_to 'タスク一覧', tasks_path, class: "header-title-task-tab" %>
       </div>
       <div class="content-body">
+        <%= pie_chart @progress_percentage, class: "percentage-graph", library: {title: {text: "#{@progress_percentage[:read]}%" }} %>
         <table class="table table-bordered table-sm">
           <tr>
             <th scope="row">本のタイトル</th>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -43,9 +43,9 @@
         </table>
         <%= link_to "編集", edit_task_path(@task) %>
         <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
-      </div>
 
-      <%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>
+        <%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,45 +1,51 @@
-<div class="main-wrapper">
-  <div class="content-with-header">
-    <div class="content-header">
-      <div class="header-title">タスク詳細</div>
-    </div>
-    <div class="content-body">
-      <table class="table table-bordered table-sm">
-        <tr>
-          <th scope="row">本のタイトル</th>
-          <td><%= @task.book.title %></td>
-        </tr>
-        <tr>
-          <th scope="row">ページ数</th>
-          <td><%= @task.book.page_count %></td>
-        </tr>
-        <tr>
-          <th scope="row">開始日</th>
-          <td><%= @task.started_on %></td>
-        </tr>
-        <tr>
-          <th scope="row">目標日</th>
-          <td><%= @task.finished_on %></td>
-        </tr>
-        <tr>
-          <th scope="row">目標日まで</th>
-          <td>あと<%= @progress_data[0][:left_days] %>日</td>
-        </tr>
-        <tr>
-          <th scope="row">1日の目標ページ数</th>
-          <td><%= @progress_data[0][:daily_goal_pages] %></td>
-        </tr>
-        <tr>
-          <th scope="row">進捗率</th>
-          <td>
-            <%= render 'percentage', percentage: @progress_data[0][:percentage] %>
-          </td>
-        </tr>
-      </table>
-      <%= link_to "編集", edit_task_path(@task) %>
-      <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
+<div class="task-wrapper">
+  <div class="side-wrapper">
+    <%= render 'side' %>
+  </div>
+  <div class="main-wrapper-task">
+    <div class="content-with-header">
+      <div class="content-header">
+        <%= link_to 'タスク', task_path(@first_task.id), class: "header-title-task-tab selected" %>
+        <%= link_to 'タスク一覧', tasks_path, class: "header-title-task-tab" %>
+      </div>
+      <div class="content-body">
+        <table class="table table-bordered table-sm">
+          <tr>
+            <th scope="row">本のタイトル</th>
+            <td><%= @task.book.title %></td>
+          </tr>
+          <tr>
+            <th scope="row">ページ数</th>
+            <td><%= @task.book.page_count %></td>
+          </tr>
+          <tr>
+            <th scope="row">開始日</th>
+            <td><%= @task.started_on %></td>
+          </tr>
+          <tr>
+            <th scope="row">目標日</th>
+            <td><%= @task.finished_on %></td>
+          </tr>
+          <tr>
+            <th scope="row">目標日まで</th>
+            <td>あと<%= @task_progress_data[0][:left_days] %>日</td>
+          </tr>
+          <tr>
+            <th scope="row">1日の目標ページ数</th>
+            <td><%= @task_progress_data[0][:daily_goal_pages] %></td>
+          </tr>
+          <tr>
+            <th scope="row">進捗率</th>
+            <td>
+              <%= render 'percentage', percentage: @task_progress_data[0][:percentage] %>
+            </td>
+          </tr>
+        </table>
+        <%= link_to "編集", edit_task_path(@task) %>
+        <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
+      </div>
+
+      <%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>
     </div>
   </div>
 </div>
-
-<%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,0 +1,35 @@
+Chartkick.options = {
+  height: "250px",
+  width: "500px",
+  donut: true, # ドーナツグラフ
+  colors: [ "#4756ca",
+            "#bdbdbd"
+          ],
+  message: { empty: "データがありません" },
+  suffix: "%",
+  legend: false, # 凡例非表示
+  library: {
+    title: { # タイトル表示(ここでは、グラフの真ん中に配置して,viewでデータを渡しています。*後述)
+      align: 'center',
+      verticalAlign: 'middle',
+      style: {
+        color: "#163172",
+        fontWeight: "bold",
+        fontSize: "30px"
+      }
+    },
+    plotOptions: {
+      series: {
+        enableMouseTracking: false
+      },
+      pie: {
+        dataLabels: {
+          enabled: false,
+        },
+        size: '110%',
+        innerSize: '60%', # ドーナツグラフの中の円の大きさ
+        borderWidth: 0,
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
     "bootstrap": "^4.6.0",
+    "chart.js": "^3.4.1",
+    "chartkick": "^4.0.5",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^4.6.0",
     "chart.js": "^3.4.1",
     "chartkick": "^4.0.5",
+    "highcharts": "^9.1.2",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3468,6 +3468,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highcharts@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.1.2.tgz#c9b15390a10acb274a941d2aa5bc05c0889646d9"
+  integrity sha512-RwCnJnxAUCGG4R/WDG+QP/4VJNtOpkQTkXcuf58DjDvm9ZILplSMdZvrbMRC9Y9ecuJQCjjZsiifvyS5E2IBvQ==
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,25 @@ chalk@^2.0, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chart.js@>=3.0.2, chart.js@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.4.1.tgz#ff3b2b2a04a37b83618b4a6399a5f87ccc0f1e8a"
+  integrity sha512-0R4mL7WiBcYoazIhrzSYnWcOw6RmrRn7Q4nKZNsBQZCBrlkZKodQbfeojCCo8eETPRCs1ZNTsAcZhIfyhyP61g==
+
+chartjs-adapter-date-fns@>=2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-2.0.0.tgz#5e53b2f660b993698f936f509c86dddf9ed44c6b"
+  integrity sha512-rmZINGLe+9IiiEB0kb57vH3UugAtYw33anRiw5kS2Tu87agpetDDoouquycWc9pRsKtQo5j+vLsYHyr8etAvFw==
+
+chartkick@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-4.0.5.tgz#310a60c931e8ceedc39adee2ef8e9d1e474cb0e6"
+  integrity sha512-xKak4Fsgfvp1hj/LykRKkniDMaZASx2A4TdVc/sfsiNFFNf1m+D7PGwP1vgj1UsbsCjOCSfGWWyJpOYxkUCBug==
+  optionalDependencies:
+    chart.js ">=3.0.2"
+    chartjs-adapter-date-fns ">=2.0.0"
+    date-fns ">=2.0.0"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -2430,6 +2449,11 @@ dashdash@^1.12.0:
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@>=2.0.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
## 93
close #93

## 実装内容
- タスク一覧ページとタスク詳細ページのリンクを変更
  - ヘッダーのリンクをタスク詳細ページへのリンクに変更
  - リンクのデザインをタブ風に変更
- タスク一覧ページのデザインを変更
  - 今日何ページまで読むかの目標を計算メソッドに追加、タスク一覧ページに表示
- タスク詳細ページのデザインを変更
  - 進捗一覧の表示を変更
  - ドーナツグラフの実装のためgem chartkick をインストール
  - 進捗率のグラフのデータを用意
  - 進捗率グラフを表示、デザインを設定

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
