### PR TITLE
[fix]ヘッダーメニューのレイアウトを修正

### DIFF
--- a/app/assets/stylesheets/modules/_firstview.scss
+++ b/app/assets/stylesheets/modules/_firstview.scss
@@ -50,24 +50,25 @@
       letter-spacing: 0.1em;
       text-shadow: 2px 2px 10px #777, -2px 2px 10px #777, 2px -2px 10px #777, -2px -2px 10px #777;
     }
+  }
 
-    .Firstview__img {
-      position: absolute;
-      top: 0;
-      right: 0;
-      z-index: -1;
+  .Firstview__background {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: -1;
+    @extend %firstview-width;
+    margin: 0;
+    padding: 10px;
+
+    .Firstview__image {
+      display: block;
       @extend %firstview-width;
-      margin: 0;
-      padding: 10px;
-
-      img {
-        @extend %firstview-width;
-        @extend %firstview-height;
-        border: none;
-        border-radius: 30px;
-        object-fit: cover;
-        object-position: 100% 70%;
-      }
+      @extend %firstview-height;
+      border: none;
+      border-radius: 30px;
+      object-fit: cover;
+      object-position: 100% 70%;
     }
   }
 }

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -40,7 +40,7 @@
     position: fixed;
     top: 0;
     right: 0;
-    z-index: 1;
+    z-index: 100;
     width: calc(100% - 40vw);
     @include mq($md) {
       width: calc(100% - 50vw);
@@ -65,22 +65,11 @@
     flex-flow: column;
     justify-content: center;
     align-items: center;
+    position: relative;
     width: calc(5vw + 40px);
     border-left: 1px solid $color-white;
     color: $color-white;
     font-weight: bold;
-  }
-
-  .Header__list-submenu {
-    display: none;
-    position: absolute;
-    top: calc(5vw + 40px);
-    right: 0;
-    margin: 0;
-    padding: 0 3vw 3vw 1vw;
-    border-radius: 0 0 50% 50%;
-    background-color: $color-main;
-    color: $color-white;
   }
 
   .Header__icon {

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -97,36 +97,4 @@
   .Header__for-margin {
     margin-right: 3px;
   }
-
-  .Header__head {
-    display: flex;
-    align-items: center;
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding: 0.5em;
-    color: $color-second;
-    font-weight: 700;
-    font-size: calc(-0.4vw + 1rem);
-
-    &.--item {
-      margin-top: 0;
-      margin-bottom: 1em;
-      padding-bottom: 0;
-      border: 0;
-
-      a {
-        color: $color-white;
-      }
-    }
-
-    &.--last {
-      margin-bottom: 2em;
-    }
-  }
-
-  .Header__text-account {
-    transform: translateY(0.2em);
-    font-family: $font-google;
-    font-weight: 700;
-  }
 }

--- a/app/assets/stylesheets/modules/_header_menu.scss
+++ b/app/assets/stylesheets/modules/_header_menu.scss
@@ -94,10 +94,4 @@
       margin-bottom: 2em;
     }
   }
-
-  .HeaderMenu__content-text {
-    transform: translateY(0.2em);
-    font-family: $font-google;
-    font-weight: 700;
-  }
 }

--- a/app/assets/stylesheets/modules/_header_menu.scss
+++ b/app/assets/stylesheets/modules/_header_menu.scss
@@ -1,0 +1,88 @@
+.HeaderMenu {
+  .HeaderMenu__toggle {
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .HeaderMenu__toggle-icon {
+    height: calc(1.6vw + 23px);
+    color: #fff;
+    transition: transform 0.6s ease-in-out, top 0.5s ease, bottom 0.5s ease;
+
+    &::before {
+      font-family: 'Font Awesome 5 Free';
+      content: '\f7a4';
+    }
+
+    &.show::before {
+      font-weight: 700;
+      line-height: 1;
+      content: '×';
+    }
+  }
+
+  .HeaderMenu__toggle-text {
+    overflow: hidden;
+    color: $color-white;
+    font-size: 1vw;
+    font-family: $font-google;
+  }
+
+  .HeaderMenu__content {
+    display: block;
+    position: absolute;
+    top: calc(5vw + 40px);
+    right: 0.5em;
+    width: 50vw;
+    @include mq($md) {
+      width: 40vw;
+    }
+    height: auto;
+    border-radius: 20px;
+    padding: 1.6em 0;
+    background-color: $color-main;
+    opacity: 0.9;
+    visibility: hidden;
+    filter: drop-shadow(0 0.4em 0.8em rgba(0, 0, 0, 0.2));
+    transition: opacity 0.2s ease;
+
+    &.show {
+      visibility: visible;
+    }
+  }
+
+  .HeaderMenu__content-head {
+    display: flex;
+    align-items: center;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    padding: 0.5em;
+    color: $color-second;
+    font-weight: 700;
+    font-size: calc(-0.4vw + 1rem);
+
+    &.--item {
+      margin-top: 0;
+      margin-bottom: 1em;
+      padding-bottom: 0;
+      border: 0;
+
+      a {
+        color: $color-white;
+      }
+    }
+
+    &.--last {
+      margin-bottom: 2em;
+    }
+  }
+
+  .HeaderMenu__content-text {
+    transform: translateY(0.2em);
+    font-family: $font-google;
+    font-weight: 700;
+  }
+}

--- a/app/assets/stylesheets/modules/_header_menu.scss
+++ b/app/assets/stylesheets/modules/_header_menu.scss
@@ -36,39 +36,54 @@
     position: absolute;
     top: calc(5vw + 40px);
     right: 0.5em;
-    width: 50vw;
+    width: 20vw;
     @include mq($md) {
       width: 40vw;
     }
     height: auto;
     border-radius: 20px;
-    padding: 1.6em 0;
+    padding: 0.5em 0 0.5em 1em;
     background-color: $color-main;
-    opacity: 0.9;
-    visibility: hidden;
-    filter: drop-shadow(0 0.4em 0.8em rgba(0, 0, 0, 0.2));
-    transition: opacity 0.2s ease;
+    // フェードインの設定
+    opacity: 0;
+    transform: translateX(300px);
+    transition: transform 0.5s;
 
     &.show {
-      visibility: visible;
+      opacity: 0.9;
+      transform: translateX(0);
     }
   }
 
-  .HeaderMenu__content-head {
+  .HeaderMenu__list-text {
     display: flex;
     align-items: center;
     margin-top: 1em;
     margin-bottom: 1em;
-    padding: 0.5em;
+    padding-left: 0.5em;
     color: $color-second;
-    font-weight: 700;
-    font-size: calc(-0.4vw + 1rem);
+
+    &.--head {
+      transform: translateY(0.2em);
+      font-family: $font-google;
+      font-weight: 700;
+      font-size: calc(0.4vw + 1rem);
+    }
+
+    &.--top {
+      width: 90%;
+      padding-bottom: 0.5em;
+      border-bottom: solid 1px $color-white;
+
+      a {
+        color: $color-second;
+      }
+    }
 
     &.--item {
-      margin-top: 0;
-      margin-bottom: 1em;
-      padding-bottom: 0;
+      padding-left: 1em;
       border: 0;
+      font-size: calc(0.4vw + 0.8rem);
 
       a {
         color: $color-white;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,7 +2,7 @@ import 'bootstrap/dist/js/bootstrap';
 import 'jquery';
 import './daily_goal.js'; // 1日あたりのページ数計算
 import './search_form.js'; //書籍検索を空白時に無効化
-import './toggle_menu.js'; //ヘッダーのトグルメニュー
+import './js-header_menu.js'; //ヘッダーのトグルメニュー
 import 'chartkick/highcharts';
 
 // This file is automatically compiled by Webpack, along with any other files

--- a/app/javascript/packs/js-header_menu.js
+++ b/app/javascript/packs/js-header_menu.js
@@ -1,0 +1,7 @@
+document.addEventListener('turbolinks:load', function () {
+  $('.js-HeaderMenu__toggle').each(function () {
+    $(this).on('click', function () {
+      $('.js-HeaderMenu__toggle-icon, .js-HeaderMenu__content').toggleClass('show');
+    });
+  });
+});

--- a/app/javascript/packs/js-header_menu.js
+++ b/app/javascript/packs/js-header_menu.js
@@ -5,7 +5,7 @@ document.addEventListener('turbolinks:load', function () {
   });
 
   $(document).on('click touchend', function (event) {
-    if (!$(event.target).closest('.js-HeaderMenu__content').length) {
+    if (!$(event.target).closest('.js-HeaderMenu__content, .js-HeaderMenu__toggle').length) {
       $('.js-HeaderMenu__toggle-icon, .js-HeaderMenu__content').removeClass('show');
     }
   });

--- a/app/javascript/packs/js-header_menu.js
+++ b/app/javascript/packs/js-header_menu.js
@@ -1,7 +1,12 @@
 document.addEventListener('turbolinks:load', function () {
-  $('.js-HeaderMenu__toggle').each(function () {
-    $(this).on('click', function () {
-      $('.js-HeaderMenu__toggle-icon, .js-HeaderMenu__content').toggleClass('show');
-    });
+  $('.js-HeaderMenu__toggle').on('click', function () {
+    $('.js-HeaderMenu__toggle-icon, .js-HeaderMenu__content').toggleClass('show');
+    return false;
+  });
+
+  $(document).on('click touchend', function (event) {
+    if (!$(event.target).closest('.js-HeaderMenu__content').length) {
+      $('.js-HeaderMenu__toggle-icon, .js-HeaderMenu__content').removeClass('show');
+    }
   });
 });

--- a/app/javascript/packs/toggle_menu.js
+++ b/app/javascript/packs/toggle_menu.js
@@ -1,8 +1,0 @@
-document.addEventListener('turbolinks:load', function () {
-  $('.js-list-menu').each(function () {
-    $(this).on('click', function () {
-      $('+.js-list-submenu', this).slideToggle();
-      return false;
-    });
-  });
-});

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,10 +11,11 @@
         <%= render "books/search_form" %>
       </div>
     </div>
+  </div>
 
-    <div class="Firstview__img">
-      <%= image_tag 'top' %>
-    </div>
+  <div class="Firstview__background">
+    <%= image_tag 'top', class: "Firstview__image" %>
+  </div>
   </section>
 
   <div class="c-container">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,13 +17,14 @@
             </div>
             <div class="HeaderMenu__content js-HeaderMenu__content">
               <ul class="HeaderMenu__list">
-                <div class="HeaderMenu__content-head">
-                  <span class="HeaderMenu__content-text">ACCOUNT</span>
+                <div class="HeaderMenu__list-text --head --top">
+                  <%= link_to "TOP", root_path %>
                 </div>
-                <li class="HeaderMenu__content-head --item">
+                <div class="HeaderMenu__list-text --head">ACCOUNT</div>
+                <li class="HeaderMenu__list-text --item">
                   <%= link_to "編集", edit_user_registration_path %>
                 </li>
-                <li class="HeaderMenu__content-head --item --last">
+                <li class="HeaderMenu__list-text --item --last">
                   <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
                 </li>
               </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,21 +9,27 @@
           <div class="Header__icon"><i class="far fa-bookmark"></i></div>
           <div class="Header__text"><span class="Header__for-margin">MY</span>PAGE</div>
         <% end %>
-        <a class="Header__list-item js-list-menu" href="">
-          <div class="Header__icon"><i class="fas fa-grip-lines"></i></div>
-          <div class="Header__text">MENU</div>
-        </a>
-        <ul class="Header__list-submenu js-list-submenu">
-          <div class="Header__head">
-            <span class="Header__text-account">ACCOUNT</span>
+        <div class="Header__list-item">
+          <div class="HeaderMenu">
+            <div class="HeaderMenu__toggle js-HeaderMenu__toggle">
+              <div class="HeaderMenu__toggle-icon js-HeaderMenu__toggle-icon"></div>
+              <div class="HeaderMenu__toggle-text">MENU</div>
+            </div>
+            <div class="HeaderMenu__content js-HeaderMenu__content">
+              <ul class="HeaderMenu__list">
+                <div class="HeaderMenu__content-head">
+                  <span class="HeaderMenu__content-text">ACCOUNT</span>
+                </div>
+                <li class="HeaderMenu__content-head --item">
+                  <%= link_to "編集", edit_user_registration_path %>
+                </li>
+                <li class="HeaderMenu__content-head --item --last">
+                  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
+                </li>
+              </ul>
+            </div>
           </div>
-          <li class="Header__head --item">
-            <%= link_to "編集", edit_user_registration_path %>
-          </li>
-          <li class="Header__head --item --last">
-            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-          </li>
-        </ul>
+        </div>
       <% else %>
         <%= link_to users_guest_sign_in_path, method: :post, class: "Header__list-item" do %>
           <div class="Header__icon"><i class="fas fa-sign-in-alt"></i></div>


### PR DESCRIPTION
## 100
close #100

## 実装内容
- HeaderMenu ブロックを作成し、ハンバーガーメニューの表示方法を変更
  - HeaderMenu__content を右からフェードインする表示に変更
  - ヘッダーメニューのデザインを変更

- HeaderMenu__content を領域外をクリックで閉じる様に変更
  - ヘッダー、Firstview背景画像の重なり順を調整
  - ヘッダーメニュー用の jsファイルを更新

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
