### PR TITLE
書籍情報登録ページのレイアウトを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -477,27 +477,6 @@ a.selected {
   }
 }
 
-/* 書籍新規登録ページ */
-
-.book-new-btn {
-  margin: 0 auto 20px 20px;
-
-  .btn-book-new-submit {
-    width: 100%;
-    width: 120px;
-    margin: 0 auto 10px 0;
-    display: block;
-    background: #4756ca;
-    border-radius: 100px;
-    border: 1px solid #4756ca;
-    box-sizing: border-box;
-    color: #fcfcfc !important;
-    font-size: 16px;
-    font-weight: bold;
-    padding: 5px;
-  }
-}
-
 /* タスク新規登録ページ */
 
 .caption-task-new {

--- a/app/assets/stylesheets/modules/_book_new.scss
+++ b/app/assets/stylesheets/modules/_book_new.scss
@@ -1,0 +1,113 @@
+.BookNew {
+  .BookNew__top {
+    position: relative;
+  }
+
+  .BookNew__close-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: calc(0.5vw + 40px);
+    height: calc(0.5vw + 40px);
+    margin: calc(0.5vw + 10px);
+    border-radius: 50%;
+    background-color: $color-main;
+    text-align: center;
+  }
+
+  .BookNew__close-button-text {
+    color: $color-white;
+    font-weight: 700;
+    line-height: calc(0.5vw + 40px);
+  }
+
+  .BookNew__tittle,
+  .BookNew__data dt,
+  .BookNew__data dd {
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+  }
+
+  .BookNew__title {
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin: calc(0.5vw + 20px);
+    margin-top: calc(0.5vw + 40px);
+    margin-left: calc(1vw + 30px);
+    font-weight: 700;
+    font-size: calc(0.2vw + 1rem);
+    line-height: 1.4;
+
+    &::before {
+      flex: 0 0 1em;
+      width: 1em;
+      height: 2px;
+      margin-right: 0.5em;
+      background-color: $color-second;
+      content: '';
+    }
+  }
+
+  .BookNew__content {
+    display: flex;
+    margin: calc(0.5vw + 25px) auto;
+    padding: 0 calc(1.6vw + 13px);
+  }
+
+  .BookNew__image {
+    flex-basis: calc(0.2vw + 132px);
+    margin-left: 10px;
+    overflow: hidden;
+  }
+
+  .BookNew__data {
+    flex-basis: calc(100% - (0.2vw + 132px));
+    display: flex;
+    flex-flow: column;
+    justify-content: space-around;
+
+    dl {
+      display: flex;
+      margin-left: calc(0.5vw + 5px);
+      font-size: calc(0.2vw + 11px);
+      line-height: 1;
+    }
+
+    dt {
+      flex-basis: calc(3vw + 40px);
+      justify-content: center;
+      width: auto;
+      padding: 10px 0 10px;
+      background-color: $color-beige;
+      font-weight: 600;
+    }
+
+    dd {
+      flex-basis: calc(90% - (3vw + 40px));
+      padding: 5px 0 5px 5px;
+      margin-left: 5px;
+      border-bottom: 1px solid;
+    }
+  }
+
+  .BookNew__submit {
+    width: 100%;
+    padding: 0 calc(1vw + 40px);
+    margin-bottom: calc(1.6vw + 13px);
+  }
+
+  .BookNew__submit-button {
+    position: relative;
+    width: 100%;
+    padding: 1em calc(0.8vw + 16px);
+    border-radius: 20px;
+    background-color: $color-main;
+    color: #fff;
+    font-weight: 700;
+    font-size: calc(0.3vw + 1rem);
+    line-height: 1.5;
+  }
+}

--- a/app/assets/stylesheets/modules/_search_list.scss
+++ b/app/assets/stylesheets/modules/_search_list.scss
@@ -43,7 +43,7 @@
 
       &:hover {
         border: 3px solid $color-main;
-        background-color: #f0f0f0;
+        background-color: rgba(33, 158, 188, 0.3);
         opacity: 0.7;
         transition-duration: 0.3s;
       }

--- a/app/views/books/_modal_new.html.erb
+++ b/app/views/books/_modal_new.html.erb
@@ -1,36 +1,37 @@
 <div class="modal-dialog">
   <div class="modal-content">
 
-    <div class="content-with-header">
-      <div class="content-header">
-        <div class="header-title">書籍の新規登録</div>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+    <div class="BookNew">
+      <div class="BookNew__top">
+        <div class="BookNew__close-button">
+          <button type="button" data-dismiss="modal" aria-label="Close">
+            <span class="BookNew__close-button-text" aria-hidden="true">&times;</span>
+          </button>
+        </div>
       </div>
-
-      <div class="content-body">
-        <table class="table table-bordered table-sm">
-          <tr>
-            <th scope="row">タイトル</th>
-            <td><%= @book.title %></td>
-          </tr>
-          <tr>
-            <th scope="row">著者</th>
-            <td><%= @book.author %></td>
-          </tr>
-          <tr>
-            <th scope="row">ページ数</th>
-            <td><%= @book.page_count %></td>
-          </tr>
-        </table>
-        <%= image_tag @book.image_link if @book.image_link? %>
-      </div>
+      <div class="BookNew__title">書籍の新規登録</div>
+        <div class="BookNew__content">
+          <div class="BookNew__image"><%= image_tag @book.image_link if @book.image_link? %></div>
+          <div class="BookNew__data">
+            <dl>
+              <dt>タイトル</dt>
+              <dd><%= @book.title %></dd>
+            </dl>
+            <dl>
+              <dt>著者</dt>
+              <dd><%= @book.author %></dd>
+            </dl>
+            <dl>
+              <dt>ページ数</dt>
+              <dd><%= @book.page_count %>ページ</dd>
+            </dl>
+          </div>
+        </div>
 
         <% if @book.persisted? %>
-          <div class="book-new-btn">
+          <div class="BookNew__submit">
             <%= link_to(controller: :tasks, action: :new, book_id: @book.id) do %>
-              <button class="btn btn-book-new-submit">登録</button>
+              <button class="BookNew__submit-button btn">登録</button>
             <% end %>
           </div>
         <% else %>
@@ -40,8 +41,8 @@
             <%= f.hidden_field :author, value:@book.author %>
             <%= f.hidden_field :image_link, value:@book.image_link %>
             <%= f.hidden_field :page_count, value:@book.page_count %>
-            <div class="book-new-btn">
-              <%= f.submit "登録", class: "btn btn-book-new-submit" %>
+            <div class="BookNew__submit">
+              <%= f.submit "登録", class: "BookNew__submit-button btn" %>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
## 90
close #90

## 実装内容
- 検索結果リストのhover色を透過メインカラーに変更
- 書籍新規登録ページのHTMLクラス名を変更
- 書籍新規登録ページのスタイルを変更
- 変更前のCSS記述を削除

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
