### PR TITLE
[fix]タスクページのリンク関連を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,11 +11,17 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resorce)
-    tasks_path
+    if @first_task
+      task_path(@first_task.id)
+    else
+      tasks_path
+    end
   end
 
   def first_task
-    task = Task.joins(:reads).order(read_on: :desc).limit(1)
-    @first_task = task[0]
+    if user_signed_in?
+      task = current_user.tasks.joins(:reads).order(read_on: :desc).limit(1)
+      @first_task = task[0]
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,13 @@
 module ApplicationHelper
-  def max_width
-    "mw-xl"
+
+  # ユーザーのタスク登録の有無に応じてリンク先を分ける
+  def link_task_show_or_index
+    if user_signed_in?
+      if @first_task # application_controllerで定義
+        task_path(@first_task.id)
+      else
+        tasks_path
+      end
+    end
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
   <div class="Header__container">
     <div class="Header__list">
       <% if user_signed_in? %>
-        <%= link_to task_path(first_task.id), class: "Header__list-item" do %>
+        <%= link_to link_task_show_or_index, class: "Header__list-item" do %>
           <div class="Header__icon"><i class="far fa-bookmark"></i></div>
           <div class="Header__text"><span class="Header__for-margin">MY</span>PAGE</div>
         <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,7 +6,11 @@
   <div class="main-wrapper-task">
     <div class="content-with-header">
       <div class="content-header">
-        <%= link_to 'タスク', task_path(@first_task.id), class: "header-title-task-tab" %>
+        <% if @first_task %>
+          <%= link_to 'タスク', task_path(@first_task.id), class: "header-title-task-tab" %>
+        <% else %>
+          <div class="header-title-task-tab">タスク</div>
+        <% end %>
         <%= link_to 'タスク一覧', tasks_path, class: "header-title-task-tab selected" %>
       </div>
       <div class="content-body">

--- a/app/views/tasks/today.html.erb
+++ b/app/views/tasks/today.html.erb
@@ -1,0 +1,7 @@
+<div class="TaskToday">
+  <%= render partial: 'shared/page_top', locals: {main: "Today", sub: "今日の目標"} %>
+  <%= render 'shared/breadcrumbs' %>
+
+  <div class="c-container">
+  </div>
+</div>


### PR DESCRIPTION
## 106
close #106

## 実装内容
- 他ユーザーがURL直打ちによってタスクの閲覧、修正、削除ができないように設定
- ユーザーのタスクの有無によってリンク先を詳細ページか一覧ページに条件分岐するようにヘルパーを定義
- ユーザーが今日のタスクを一覧できるページを追加

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
