### PR TITLE
[fix]進捗新規登録ページのレイアウト修正

### DIFF
--- a/app/assets/stylesheets/modules/_read_form.scss
+++ b/app/assets/stylesheets/modules/_read_form.scss
@@ -1,0 +1,115 @@
+.ReadForm {
+  .ReadForm__content {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding-top: 20px;
+  }
+
+  .ReadForm__data {
+    display: flex;
+    flex-flow: column;
+    flex-basis: 20%;
+    align-items: center;
+    align-self: baseline;
+    margin-top: calc(1vw + 10px);
+    margin-right: calc(1vw + 5px);
+  }
+
+  .ReadForm__book-image {
+    .BookImage__cover {
+      width: auto;
+      height: 100px;
+    }
+  }
+
+  .ReadForm__page {
+    display: flex;
+    margin-bottom: 3px;
+  }
+
+  .ReadForm__page-title {
+    height: 20px;
+    padding: 0 5px;
+    border-top: 1px solid $color-gray;
+    border-bottom: 1px solid $color-gray;
+    border-left: 1px solid $color-gray;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    background-color: $color-gray;
+    color: $color-white;
+    font-size: calc(0.2vw + 10px);
+    line-height: 18px;
+  }
+
+  .ReadForm__page-count {
+    padding: 0 5px;
+    height: 20px;
+    border-top: 1px solid $color-gray;
+    border-bottom: 1px solid $color-gray;
+    border-right: 1px solid $color-gray;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    color: #444;
+    font-size: calc(0.2vw + 10px);
+    line-height: 18px;
+  }
+
+  .ReadForm__field {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1.5em;
+  }
+
+  .ReadForm__book-image {
+    width: 100%;
+  }
+
+  .ReadForm__caption {
+    flex: 0 0 40%;
+    max-width: 40%;
+    padding-right: 1em;
+    font-weight: 700;
+  }
+
+  .ReadForm__input {
+    flex: 0 0 60%;
+    max-width: 60%;
+
+    input[type='text'],
+    input[type='date'] {
+      width: 100%;
+      padding: 1em;
+      border: 0 !important;
+      border-radius: 0.5em;
+      background-color: rgba(33, 158, 188, 0.1);
+      font-size: inherit;
+      line-height: inherit;
+      font-family: inherit;
+      letter-spacing: inherit;
+      outline: 0;
+    }
+  }
+
+  .ReadForm__submit {
+    position: relative;
+    width: 100%;
+    padding: 0 calc(1vw + 40px);
+    margin-bottom: calc(1.6vw + 13px);
+  }
+
+  .ReadForm__submit-button {
+    position: relative;
+    left: calc(5vw - 10px);
+    width: 100%;
+    max-width: calc(1vw + 300px);
+    padding: 1em calc(0.8vw + 16px);
+    border-color: $color-main;
+    border-radius: 20px;
+    background-color: $color-main;
+    color: #fff;
+    font-weight: 700;
+    font-size: calc(0.3vw + 1rem);
+    line-height: 1.5;
+  }
+}

--- a/app/assets/stylesheets/modules/_read_new.scss
+++ b/app/assets/stylesheets/modules/_read_new.scss
@@ -1,0 +1,8 @@
+.ReadNew {
+  .ReadNew__wrapper {
+    padding: 10px;
+    border-radius: 30px;
+    background-clip: content-box;
+    background-color: $color-beige;
+  }
+}

--- a/app/assets/stylesheets/modules/_read_new_card.scss
+++ b/app/assets/stylesheets/modules/_read_new_card.scss
@@ -1,34 +1,21 @@
 .ReadNewCard {
-  display: flex;
-  margin: 10px;
+  max-width: 800px;
+  margin: 15px;
+  border-radius: 10px;
   background-color: $color-white;
 
   .ReadNewCard__container {
     position: relative;
     width: 100%;
+    max-width: 600px;
     padding: 15px;
   }
 
   .ReadNewCard__title {
-    width: 60%;
+    width: 90%;
     margin: 5px;
     border-bottom: solid 2px;
     overflow: hidden;
     white-space: nowrap;
-  }
-
-  .ReadNewCard__content {
-    display: flex;
-    align-items: center;
-    width: 100%;
-  }
-
-  .ReadNewCard__book-image {
-    flex-basis: 15%;
-
-    .BookImage__cover {
-      width: auto;
-      height: 100px;
-    }
   }
 }

--- a/app/assets/stylesheets/modules/_read_new_card.scss
+++ b/app/assets/stylesheets/modules/_read_new_card.scss
@@ -1,0 +1,34 @@
+.ReadNewCard {
+  display: flex;
+  margin: 10px;
+  background-color: $color-white;
+
+  .ReadNewCard__container {
+    position: relative;
+    width: 100%;
+    padding: 15px;
+  }
+
+  .ReadNewCard__title {
+    width: 60%;
+    margin: 5px;
+    border-bottom: solid 2px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .ReadNewCard__content {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .ReadNewCard__book-image {
+    flex-basis: 15%;
+
+    .BookImage__cover {
+      width: auto;
+      height: 100px;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_task_today_card.scss
+++ b/app/assets/stylesheets/modules/_task_today_card.scss
@@ -68,6 +68,8 @@
     line-height: 50px;
 
     &.--main {
+      border-color: $color-main;
+      color: $color-white;
       background-color: $color-main;
     }
   }

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -3,15 +3,19 @@ class ReadsController < ApplicationController
   before_action :set_read, only: %i[edit update destroy]
 
   def new
-    @read = Read.new
+    if params
+      @read = Read.new(read_on: params[:read_on])
+    else
+      @read = Read.new
+    end
   end
 
   def create
     @read = @task.reads.build(read_params)
     if @read.save
-      redirect_to task_path(@task.id), notice: "登録しました"
+      redirect_to @read, notice: "進捗を登録しました。"
     else
-      flash.now[:alert] = "登録に失敗しました"
+      flash.now[:alert] = "進捗の登録に失敗しました。"
       render :new
     end
   end

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -13,7 +13,7 @@ class ReadsController < ApplicationController
   def create
     @read = @task.reads.build(read_params)
     if @read.save
-      redirect_to @read, notice: "進捗を登録しました。"
+      redirect_to today_tasks_path, notice: "進捗を登録しました。"
     else
       flash.now[:alert] = "進捗の登録に失敗しました。"
       render :new

--- a/app/views/reads/_form.html.erb
+++ b/app/views/reads/_form.html.erb
@@ -1,22 +1,37 @@
-<%= form_with model: [task, read], local: true do |f| %>
-  <%= render 'shared/error_messages', model: f.object %>
-  <div class="form-field">
-    <div class="field-caption">
-      <%= f.label :read_on %>
+<div class="ReadForm">
+  <%= form_with model: [task, read], local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
+    <div class="ReadForm__content">
+      <div class="ReadForm__data">
+        <div class="ReadForm__book-image">
+          <%= render partial: 'books/book_image', locals: { image_link: task.book.image_link } %>
+        </div>
+        <dl class="ReadForm__page">
+          <dt class="ReadForm__page-title">ページ数</dt>
+          <dd class="ReadForm__page-count"><%= task.book.total_pages %></dd>
+        </dl>
+      </div>
+      <div class="ReadForm__form">
+        <div class="ReadForm__field">
+          <div class="ReadForm__caption">
+            <%= f.label :read_on %>
+          </div>
+          <div class="ReadForm__input">
+            <%= f.date_field :read_on %>
+          </div>
+        </div>
+        <div class="ReadForm__field">
+          <div class="ReadForm__caption">
+            <%= f.label :up_to_page, "読み終わった<br>ページ番号".html_safe %>
+          </div>
+          <div class="ReadForm__input">
+            <%= f.text_field :up_to_page %>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="field-input">
-      <%= f.date_field :read_on %>
+    <div class="ReadForm__submit">
+      <%= f.submit button_value, class: "ReadForm__submit-button" %>
     </div>
-  </div>
-  <div class="form-field">
-    <div class="field-caption">
-      <%= f.label :up_to_page %>
-    </div>
-    <div class="field-input">
-      <%= f.text_field :up_to_page %>
-    </div>
-  </div>
-  <div class="btn-read-new">
-    <%= f.submit button_value %>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/reads/new.html.erb
+++ b/app/views/reads/new.html.erb
@@ -1,10 +1,26 @@
-<div class="main-wrapper">
-  <div class="content-with-header">
-    <div class="content-header">
-      <div class="header-title">進捗の新規登録</div>
+<div class="ReadNew">
+  <%= render partial: 'shared/page_top', locals: {main: "Read", sub: "進捗の登録"} %>
+  <div class="c-container">
+    <div class="Breadcrumbs">
+      <%= link_to 'TOP', '/' %>
+      <span class="Breadcrumbs__arrow">></span>
+      <%= link_to '今日の目標', today_tasks_path, class: "Breadcrumbs__item" %>
+      <span class="Breadcrumbs__arrow">></span>
+      <span class="Breadcrumbs__item Breadcrumbs__now">進捗の登録</span>
     </div>
-    <div class="content-body">
-      <%= render "form", task: @task, read: @read, button_value: "登録" %>
+  </div>
+
+  <div class="ReadNew__wrapper">
+    <div class="ReadNewCard">
+      <div class="ReadNewCard__container">
+        <div class="ReadNewCard__title"><%= @task.book.title %></div>
+        <div class="ReadNewCard__content">
+          <div class="ReadNewCard__book-image">
+            <%= render partial: 'books/book_image', locals: { image_link: @task.book.image_link } %>
+          </div>
+          <%= render "form", task: @task, read: @read, button_value: "登録" %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/reads/new.html.erb
+++ b/app/views/reads/new.html.erb
@@ -14,11 +14,7 @@
     <div class="ReadNewCard">
       <div class="ReadNewCard__container">
         <div class="ReadNewCard__title"><%= @task.book.title %></div>
-        <div class="ReadNewCard__content">
-          <div class="ReadNewCard__book-image">
-            <%= render partial: 'books/book_image', locals: { image_link: @task.book.image_link } %>
-          </div>
-          <%= render "form", task: @task, read: @read, button_value: "登録" %>
+        <%= render "form", task: @task, read: @read, button_value: "登録" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 111
close #111

## 実装内容
- readsコントローラのcreateアクションを修正
- 進捗新規登録の入力フォームの見た目を修正

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
