### PR TITLE
[fix]タスク詳細ページのレイアウトを修正

### DIFF
--- a/app/assets/stylesheets/modules/_read_index.scss
+++ b/app/assets/stylesheets/modules/_read_index.scss
@@ -1,0 +1,88 @@
+.ReadIndex {
+  #chart-2 {
+    width: 100%;
+    min-width: 100%;
+    max-width: 100%;
+  }
+
+  .ReadIndex__wrapper {
+    position: relative;
+    width: 95%;
+    max-width: 95%;
+    margin: 0 auto;
+    padding-top: calc(0.5vw + 20px);
+  }
+
+  .ReadIndex__title {
+    padding-left: 10%;
+    font-weight: 700;
+  }
+
+  .ReadIndex__border {
+    width: 95%;
+    margin: 10px auto;
+    border-bottom: 5px solid $color-second;
+  }
+
+  .ReadIndex__link-button {
+    display: block;
+    width: 35%;
+    max-width: 150px;
+    margin: calc(0.5vw + 0.5em) auto calc(0.5vw + 0.5em) 5%;
+    padding: 0.3em calc(0.8vw + 5px);
+    border-radius: 20px;
+    background-color: $color-main;
+    color: $color-white;
+    font-size: calc(0.3vw + 1rem);
+    font-weight: 700;
+    line-height: 1.5;
+    text-align: center;
+  }
+
+  .ReadIndex__table {
+    width: 85%;
+    margin: 0 auto;
+
+    thead {
+      border-bottom: 5px solid $color-beige;
+    }
+
+    th {
+      padding-left: 5px;
+      font-weight: normal;
+    }
+
+    th.number {
+      text-align: center;
+    }
+
+    td {
+      height: 2em;
+    }
+
+    td.number {
+      text-align: center;
+    }
+
+    .hide {
+      display: none;
+    }
+  }
+
+  .ReadIndex__reads-more {
+    width: 85%;
+    margin: 0 auto;
+    padding: 0.3em calc(0.8vw + 5px);
+    font-size: calc(0.3vw + 1rem);
+    font-weight: 700;
+    line-height: 1.5;
+    text-align: right;
+  }
+
+  .ReadIndex__message {
+    padding: 0.5em;
+    padding-bottom: 4em;
+    color: $color-gray;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/modules/_task_show.scss
+++ b/app/assets/stylesheets/modules/_task_show.scss
@@ -1,0 +1,111 @@
+.TaskShow {
+  .TaskShow__wrapper {
+    margin-top: 5px;
+    padding: 20px;
+    border-radius: 30px;
+    background-color: $color-beige;
+  }
+
+  .TaskShow__container {
+    margin: 10px;
+    background-color: $color-white;
+  }
+
+  .TaskShow__content {
+    @media screen and (min-width: 550px) {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+
+  .TaskShow__graph {
+    @media screen and (min-width: 550px) {
+      flex-basis: 50%;
+      max-width: 50%;
+    }
+  }
+
+  #chart-1 {
+    max-width: 100%;
+    margin: 0 auto;
+  }
+
+  .TaskShow__data {
+    @media screen and (min-width: 550px) {
+      flex-basis: 50%;
+      max-width: 50%;
+    }
+    padding: 10px;
+  }
+
+  .TaskShow__title {
+    width: 90%;
+    margin: 5px;
+    @media screen and (max-width: 550px) {
+      margin: 5px auto;
+      margin-bottom: 15px;
+    }
+    margin-bottom: 15px;
+    border-bottom: solid 2px;
+    overflow-wrap: break-word;
+  }
+
+  .TaskShow__item {
+    @media screen and (min-width: $xl) {
+      display: flex;
+      justify-content: space-around;
+    }
+  }
+
+  .TaskShow__book-image {
+    @media screen and (min-width: $xl) {
+      flex-basis: 40%;
+    }
+  }
+
+  .TaskShow__table {
+    margin: 0 auto;
+  }
+
+  .TaskShow__table-row {
+    display: block;
+    margin: 10px;
+    @media screen and (min-width: 550px) {
+      margin: calc(1vw + 0.5em) 10px;
+    }
+
+    td.label {
+      padding: 10px;
+      border-radius: 30px;
+      background-color: $color-beige;
+      font-weight: 700;
+    }
+  }
+
+  .TaskShow__link {
+    display: flex;
+    justify-content: space-around;
+  }
+
+  .TaskShow__link-button {
+    flex-basis: 45%;
+    max-width: 45%;
+    @media screen and (max-width: 550px) {
+      max-width: 40%;
+    }
+    margin: calc(0.5vw + 0.5em) 0;
+    padding: 0.5em calc(0.8vw + 5px);
+    border-radius: 20px;
+    background-color: $color-main;
+    color: $color-white;
+    font-size: calc(0.3vw + 1rem);
+    font-weight: 700;
+    line-height: 1.5;
+    text-align: center;
+
+    &.--delete {
+      background-color: $color-second;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_task_today_card.scss
+++ b/app/assets/stylesheets/modules/_task_today_card.scss
@@ -6,17 +6,18 @@
   }
 
   .TaskTodayCard__border {
-    margin: 10px;
     width: 10px;
     height: 200px;
+    margin: 5px;
     background-color: $color-second;
   }
 
   .TaskTodayCard__content {
+    flex-basis: 95%;
     position: relative;
+    max-width: 95%;
     padding: 15px;
     padding-left: 10px;
-    width: 100%;
   }
 
   .TaskTodayCard__link {
@@ -36,9 +37,9 @@
       transition: all 0.3s ease;
 
       &:hover {
+        opacity: 0.7;
         border: 3px solid $color-main;
         background-color: rgba(33, 158, 188, 0.3);
-        opacity: 0.7;
         transition-duration: 0.3s;
       }
     }
@@ -48,11 +49,13 @@
     position: absolute;
     top: 0;
     right: 0;
-    width: calc(0.2vw + 130px);
-    height: calc(0.2vw + 30px);
+    height: 30px;
     margin: 10px;
     padding: 5px;
     border-radius: 10px;
+    font-size: calc(0.2vw + 0.8em);
+    line-height: calc(-0.2vw + 25px);
+    text-align: center;
 
     &.--main {
       background-color: $color-main;
@@ -65,9 +68,10 @@
 
   .TaskTodayCard__title {
     width: 60%;
-    margin: 5px;
-    border-bottom: solid 2px;
+    margin-bottom: 5px;
+    padding: 5px 5px 0 5px;
     overflow: hidden;
+    border-bottom: solid 2px;
     white-space: nowrap;
   }
 
@@ -78,7 +82,8 @@
   }
 
   .TaskTodayCard__book-image {
-    flex-basis: 15%;
+    flex-basis: 20%;
+    min-width: 20%;
 
     .BookImage__cover {
       width: auto;
@@ -87,22 +92,25 @@
   }
 
   .TaskTodayCard__read {
-    margin-left: 10px;
+    margin: 10px;
+  }
+
+  .TaskTodayCard__read-circle {
+    display: inline-flex;
+    flex-flow: column;
+    justify-content: center;
+    align-items: center;
+    width: calc(0.5vw + 30px);
+    height: calc(0.5vw + 30px);
+    margin: 1px;
+    border: 2px solid $color-main;
+    border-radius: 50%;
+    color: $color-main;
+    vertical-align: top;
   }
 
   .TaskTodayCard__read-date {
-    width: 50px;
-    height: 50px;
-    padding: 5px;
-    border: solid 1px;
-    border-radius: 50%;
-    text-align: center;
-    line-height: 50px;
-
-    &.--main {
-      border-color: $color-main;
-      color: $color-white;
-      background-color: $color-main;
-    }
+    font-size: 1em;
+    line-height: 1em;
   }
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,9 +18,9 @@ class TasksController < ApplicationController
   end
 
   def show
+    @task_percentage = Task.task_percentage(@task)
     @reads = @task.reads.all.order(read_on: :desc)
-    @task_progress_data = Task.task_progress_data(@task)
-    @progress_percentage = { read: @task_progress_data[0][:percentage], unread: 100 - @task_progress_data[0][:percentage] }
+    @reads_percentage = Read.reads_percentage(@reads, @task)
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,6 +3,7 @@ import 'jquery';
 import './js-task_new.js'; // 1日あたりのページ数計算
 import './search_form.js'; //書籍検索を空白時に無効化
 import './js-header_menu.js'; //ヘッダーのトグルメニュー
+import './js-read_index.js';
 import 'chartkick/highcharts';
 
 // This file is automatically compiled by Webpack, along with any other files

--- a/app/javascript/packs/js-read_index.js
+++ b/app/javascript/packs/js-read_index.js
@@ -1,0 +1,18 @@
+document.addEventListener('turbolinks:load', function () {
+  var hideList = 'table#js-ReadIndex__table tbody#js-ReadIndex__reads tr:nth-of-type(n+6)';
+  $(hideList).hide();
+  $('#js-ReadIndex__reads-more').on('click', function () {
+    $(hideList).toggle();
+    if ($(hideList).css('display') == 'none') {
+      $('#js-ReadIndex__reads-more').text('more...');
+    } else {
+      $('#js-ReadIndex__reads-more').text('close');
+    }
+    return false;
+  });
+
+  var num = $('table#js-ReadIndex__table tbody#js-ReadIndex__reads').children('tr').length;
+  if (num < 6) {
+    $('#js-ReadIndex__reads-more').hide();
+  }
+});

--- a/app/models/read.rb
+++ b/app/models/read.rb
@@ -26,7 +26,7 @@ class Read < ApplicationRecord
     self.read_on
   end
 
-  # タスク一覧ページのサイドバーの今月、先月の読書データ
+  # タスク一覧ページの今月、先月の読書データ
   def self.month_data(user)
     max_pages = user.reads.where(read_on: Time.now.all_month).group(:task_id).maximum(:up_to_page)
     min_pages = user.reads.where(read_on: Time.now.all_month).group(:task_id).minimum(:up_to_page)
@@ -86,5 +86,19 @@ class Read < ApplicationRecord
       day_page: day_page,
       month_book: month_book
     }
+  end
+
+  def self.reads_percentage(reads, task)
+    reads_percentage = {}
+    if reads
+      reads.reverse.each do |read|
+          percentage = 100 * read.up_to_page / task.book.total_pages
+          reads_percentage.store(
+            read.read_on,
+            percentage
+          )
+      end
+    end
+    return reads_percentage
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -155,8 +155,8 @@ class Task < ApplicationRecord
   end
 
   # タスク詳細ページ
-  def self.task_progress_data(task)
-    progress_data = []
-    self.cul_progress_data(task, progress_data)
+  def self.task_percentage(task)
+    task_percentage = []
+    self.calculate_tasks_percentage(task, task_percentage)
   end
 end

--- a/app/views/reads/_index.html.erb
+++ b/app/views/reads/_index.html.erb
@@ -1,21 +1,25 @@
-<div class="reads-index">
-  <div class="content-header">
-    <div class="header-title">進捗一覧</div>
-  </div>
-  <div class="content-body">
-    <%= link_to "進捗登録", new_task_read_path(task), class: "btn btn-read-new-submit" %>
-    <table class="table table-sm table-read">
-      <thead>
-        <tr>
-          <th scope="col"></th>
-          <th scope="col">読んだ日</th>
-          <th scope="col">読んだページ数</th>
-          <th scope="col"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
-      </tbody>
-    </table>
+<div class="ReadIndex">
+  <%= area_chart reads_percentage, min: 0, max: 100 %>
+  <div class="ReadIndex__wrapper">
+    <div class="ReadIndex__title">進捗一覧</div>
+    <div class="ReadIndex__border"></div>
+    <%= link_to "新規登録", new_task_read_path(task), class: "ReadIndex__link-button" %>
+    <% if reads.present? %>
+      <table class="ReadIndex__table" id="js-ReadIndex__table">
+        <thead>
+          <tr>
+            <th>読んだ日</th>
+            <th class="number">読み終わった<br />ページ番号</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="js-ReadIndex__reads">
+          <%= render partial: "reads/read_data", locals: { task: task }, collection: reads, as: "read" %>
+        </tbody>
+      </table>
+      <div class="ReadIndex__reads-more"><a href="#" id="js-ReadIndex__reads-more">more...</a></div>
+    <% else %>
+      <div class="ReadIndex__message">進捗がありません</div>
+    <% end %>
   </div>
 </div>

--- a/app/views/reads/_read_data.html.erb
+++ b/app/views/reads/_read_data.html.erb
@@ -1,7 +1,6 @@
 <tr>
-  <th scope="row"><%= read_counter + 1 %></th>
   <td><%= read.read_on %></td>
-  <td><%= read.up_to_page %></td>
+  <td class="number"><%= read.up_to_page %></td>
   <td>
     <%= link_to "編集", edit_task_read_path(task, read) %>
     <%= link_to "削除", task_read_path(task, read), method: :delete, data: { confirm: "削除しますか?" } %>

--- a/app/views/tasks/_history_table.html.erb
+++ b/app/views/tasks/_history_table.html.erb
@@ -9,7 +9,6 @@
       <tr>
         <td class="number"><%= month_data[:month_book] %></td>
         <td class="unit">冊</td>
-        </li>
       </tr>
       <tr>
         <td class="number"><%= month_data[:day_page] %></td>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,52 +1,53 @@
-<div class="task-wrapper">
-  <div class="side-wrapper">
-    <%= render 'side' %>
+<div class="TaskShow">
+  <%= render partial: 'shared/page_top', locals: {main: "Show", sub: "目標の詳細"} %>
+  <div class="c-container">
+    <div class="Breadcrumbs">
+      <%= link_to 'TOP', '/' %>
+      <span class="Breadcrumbs__arrow">></span>
+      <%= link_to '目標の一覧', tasks_path, class: "Breadcrumbs__item" %>
+      <span class="Breadcrumbs__arrow">></span>
+      <span class="Breadcrumbs__item --now">詳細</span>
+    </div>
   </div>
-  <div class="main-wrapper-task">
-    <div class="content-with-header">
-      <div class="content-header">
-        <%# 要改善: タスクを持たない場合 %>
-        <%= link_to 'タスク', task_path(@first_task.id), class: "header-title-task-tab selected" %>
-        <%= link_to 'タスク一覧', tasks_path, class: "header-title-task-tab" %>
-      </div>
-      <div class="content-body">
-        <%= pie_chart @progress_percentage, class: "percentage-graph", library: {title: {text: "#{@progress_percentage[:read]}%" }} %>
-        <table class="table table-bordered table-sm">
-          <tr>
-            <th scope="row">本のタイトル</th>
-            <td><%= @task.book.title %></td>
-          </tr>
-          <tr>
-            <th scope="row">ページ数</th>
-            <td><%= @task.book.total_pages %></td>
-          </tr>
-          <tr>
-            <th scope="row">開始日</th>
-            <td><%= @task.started_on %></td>
-          </tr>
-          <tr>
-            <th scope="row">目標日</th>
-            <td><%= @task.finished_on %></td>
-          </tr>
-          <tr>
-            <th scope="row">目標日まで</th>
-            <td>あと<%= @task_progress_data[0][:left_days] %>日</td>
-          </tr>
-          <tr>
-            <th scope="row">1日の目標ページ数</th>
-            <td><%= @task_progress_data[0][:daily_goal_pages] %></td>
-          </tr>
-          <tr>
-            <th scope="row">進捗率</th>
-            <td>
-              <%= render 'percentage', percentage: @task_progress_data[0][:percentage] %>
-            </td>
-          </tr>
-        </table>
-        <%= link_to "編集", edit_task_path(@task) %>
-        <%= link_to "削除", @task, method: :delete, data: { confirm: "削除しますか?" } %>
 
-        <%= render partial: "reads/index", locals: { task: @task, reads: @reads } %>
+  <div class="c-container">
+    <div class="TaskShow__wrapper">
+      <div class="TaskShow__container">
+        <div class="TaskShow__content">
+          <div class="TaskShow__graph">
+            <%= pie_chart @task_percentage[0], width: "20em", height: "20em", library: {title: {text: "#{@task_percentage[0][:read]}%", style:{fontSize: "2em"} }} %>
+          </div>
+          <div class="TaskShow__data">
+            <div class="TaskShow__title"><%= @task.book.title %></div>
+            <div class="TaskShow__item">
+              <div class="TaskShow__book-image">
+                <%= render partial: 'books/book_image', locals: { image_link: @task.book.image_link } %>
+              </div>
+              <table class="TaskShow__table">
+                <tbody>
+                  <tr class="TaskShow__table-row">
+                    <td class="label">開始日</td>
+                    <td class="data"><%= @task.started_on %></td>
+                  </tr>
+                  <tr class="TaskShow__table-row">
+                    <td class="label">終了日</td>
+                    <td class="data"><%= @task.finished_on %></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="TaskShow__link">
+              <%= link_to "編集", edit_task_path(@task), class: "TaskShow__link-button --edit" %>
+              <%= link_to "削除", @task, class: "TaskShow__link-button --delete", method: :delete, data: { confirm: "削除しますか?" } %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="TaskShow__wrapper">
+      <div class="TaskShow__container">
+        <%= render partial: "reads/index", locals: { task: @task, reads: @reads, reads_percentage: @reads_percentage } %>
       </div>
     </div>
   </div>

--- a/app/views/tasks/today.html.erb
+++ b/app/views/tasks/today.html.erb
@@ -31,9 +31,11 @@
               </div>
               <div class="TaskTodayCard__read">
                 <% eval("#{val}[:read_data]").each do |date, val| %>
-                  <%= link_to new_task_read_path(task_id: task.id, read_on: date) do %>
-                    <span class="TaskTodayCard__read-date<%= val %>"><%= date.mday %></span>
-                  <% end %>
+                  <div class="TaskTodayCard__read-circle">
+                    <%= link_to new_task_read_path(task_id: task.id, read_on: date) do %>
+                      <div class="TaskTodayCard__read-date<%= val %>"><%= date.mday %></div>
+                    <% end %>
+                  </div>
                 <% end %>
               </div>
             </div>


### PR DESCRIPTION
## 117
close #117 

## 実装内容
- Taskモデルを微修正
- タスク詳細ページのレイアウトを修正し、CSSを適用
- Readモデルを微修正
- 進捗一覧のレイアウトを修正し、CSSを適用
- 進捗一覧表用のjsファイルを作成
- タスクTodayページのレイアウトを微修正

## チェックリスト

 - [x] GitHub で Files changed を確認
 - [x] 影響し得る範囲のローカル環境での動作確認
